### PR TITLE
GRIP 2.a.1 part 3

### DIFF
--- a/indicator-config/2-a-1.yml
+++ b/indicator-config/2-a-1.yml
@@ -23,7 +23,7 @@ graph_titles:
 - series: Agriculture value added share of GDP
   title: Agriculture value added share of GDP
 - series: Agriculture share of Government Expenditure
-  title: Agriculture value added share of GDP
+  title: Agriculture share of Government Expenditure
 graph_type: line
 indicator_name: global_indicators.2-a-1-title
 indicator_number: 2.a.1


### PR DESCRIPTION
- #276 
  - fix typo which was giving the wrong graph title to the Agriculture share of Government Expenditure series