### PR TITLE
GRIP 2.a.2 part 2

### DIFF
--- a/R/indicator_2-a-2.R
+++ b/R/indicator_2-a-2.R
@@ -25,8 +25,11 @@ ODA_OOF_flows_agriculture <- raw_data %>%
       "14" ~ "Other Official Flows (non Export Credit)",
       .default = Measure
     ),
+    # Get year base for USD prices from data
     Units = paste("US dollar, Millions,", Units, "constant prices"),
-  )
+  ) %>%
+  # Sort so ODA appears before OOF
+  arrange(Measure)
 
 # Sum ODA and OOF flows
 total <- ODA_OOF_flows_agriculture %>%

--- a/data/indicator_2-a-2.csv
+++ b/data/indicator_2-a-2.csv
@@ -1,6 +1,4 @@
 "Year","Units","Measure","Value"
-"2020","US dollar, Millions, 2022 constant prices","Other Official Flows (non Export Credit)",23.868986
-"2022","US dollar, Millions, 2022 constant prices","Other Official Flows (non Export Credit)",2.706805
 "2015","US dollar, Millions, 2022 constant prices","Official Development Assistance",199.046268
 "2016","US dollar, Millions, 2022 constant prices","Official Development Assistance",211.318555
 "2017","US dollar, Millions, 2022 constant prices","Official Development Assistance",174.429486
@@ -9,11 +7,13 @@
 "2020","US dollar, Millions, 2022 constant prices","Official Development Assistance",229.192371
 "2021","US dollar, Millions, 2022 constant prices","Official Development Assistance",255.125883
 "2022","US dollar, Millions, 2022 constant prices","Official Development Assistance",250.738352
-"2020","US dollar, Millions, 2022 constant prices",,253.061357
-"2022","US dollar, Millions, 2022 constant prices",,253.445157
+"2020","US dollar, Millions, 2022 constant prices","Other Official Flows (non Export Credit)",23.868986
+"2022","US dollar, Millions, 2022 constant prices","Other Official Flows (non Export Credit)",2.706805
 "2015","US dollar, Millions, 2022 constant prices",,199.046268
 "2016","US dollar, Millions, 2022 constant prices",,211.318555
 "2017","US dollar, Millions, 2022 constant prices",,174.429486
 "2018","US dollar, Millions, 2022 constant prices",,228.102558
 "2019","US dollar, Millions, 2022 constant prices",,161.990088
+"2020","US dollar, Millions, 2022 constant prices",,253.061357
 "2021","US dollar, Millions, 2022 constant prices",,255.125883
+"2022","US dollar, Millions, 2022 constant prices",,253.445157

--- a/meta/2-a-2.yml
+++ b/meta/2-a-2.yml
@@ -1,24 +1,32 @@
-SDG_GOAL: '<p>Goal 2: End hunger, achieve food security and improved nutrition and
-  promote sustainable agriculture</p>'
-SDG_TARGET: '<p>Target 2.a: Increase investment, including through enhanced international
+SDG_GOAL: 'Goal 2: End hunger, achieve food security and improved nutrition and
+  promote sustainable agriculture'
+SDG_TARGET: 'Target 2.a: Increase investment, including through enhanced international
   cooperation, in rural infrastructure, agricultural research and extension services,
   technology development and plant and livestock gene banks in order to enhance agricultural
-  productive capacity in developing countries, in particular least developed countries</p>'
-SDG_INDICATOR: '<p>Indicator 2.a.2: Total official flows (official development assistance
-  plus other official flows) to the agriculture sector</p>'
-STAT_CONC_DEF: |
-  <strong>Definition:</strong>
-  <br><br>
+  productive capacity in developing countries, in particular least developed countries'
+SDG_INDICATOR: 'Indicator 2.a.2: Total official flows (official development assistance
+  plus other official flows) to the agriculture sector'
+STAT_CONC_DEF: >
+  <strong>Definition:</strong><br>
   Gross disbursements of total official development assistance (ODA) and other official flows from Canada to the agriculture sector.
   <br><br>
-  <strong>Concepts:</strong> <br>ODA: The DAC defines ODA as “those flows to countries and territories on the DAC List of ODA Recipients and to multilateral institutions which are<br>
-  <p>i) provided by official agencies, including state and local governments, or by their executive agencies; and</p>
-  <p>ii) each transaction is administered with the promotion of the economic development and welfare of developing countries as its main objective; and is concessional in character and conveys a grant element of at least 25 per cent (calculated at a rate of discount of 10 per cent). (See http://www.oecd.org/dac/stats/officialdevelopmentassistancedefinitionandcoverage.htm)</p> <br>
-  <p>Other official flows (OOF): Other official flows (excluding officially supported export credits) are defined as transactions by the official sector which do not meet the conditions for eligibility as ODA, either because they are not primarily aimed at development, or because they are not sufficiently concessional. (See http://www.oecd.org/dac/stats/documentupload/DCDDAC(2016)3FINAL.pdf, Para 24).</p> <br>
-  <p>The agriculture sector is as defined by the DAC and comprises all CRS sector codes in the 311 series (see here: http://www.oecd.org/dac/stats/purposecodessectorclassification.htm)</p>
-DATA_COMP: |
+  <strong>Concepts:</strong><br>
+  ODA: The Development Assistance Committee (DAC) defines ODA as “those flows to countries and territories on the DAC List of ODA Recipients and to multilateral institutions which are
+  <br><br>
+  i) provided by official agencies, including state and local governments, or by their executive agencies; and
+  <br><br>
+  ii) each transaction is administered with the promotion of the economic development and welfare of developing countries as its main objective; and 
+  <br><br>
+  iii) is concessional in character and conveys a grant element of at least 25 per cent (calculated at a rate of discount of 10 per cent)”. (See http://www.oecd.org/dac/stats/officialdevelopmentassistancedefinitionandcoverage.htm)
+  <br><br>
+  Other official flows (OOF): Other official flows (excluding officially supported export credits) are defined as transactions by the official sector which do not meet the conditions for eligibility as ODA, either because they are not primarily aimed at development, or because they are not sufficiently concessional.
+  <br><br>
+  (See http://www.oecd.org/dac/stats/documentupload/DCDDAC(2016)3FINAL.pdf, Para 24).
+  <br><br>
+  The agriculture sector is as defined by the DAC and comprises all CRS sector codes in the 311 series (see here: http://www.oecd.org/dac/stats/purposecodessectorclassification.htm).
+DATA_COMP: >
   Data were readily available to report on this indicator as specified by the metadata. Please refer to the sources to access additional information on the metadata or source.
-  <br>
+  <br><br>
   Data are from the Creditor Reporting System from the OECD. Select Donor = "Canada", Recipient = "Developing countries", Sector = "Agrigulture", Measure = "Official Development Assistance" and "Other Official Flows (non Export Credit)", Flow type = "Disbursements", and Price base = "Constant prices".
 REC_USE_LIM: '   '
 SDG_GOAL__GLOBAL: '<p>Goal 2: End hunger, achieve food security and improved nutrition

--- a/meta/fr/2-a-2.yml
+++ b/meta/fr/2-a-2.yml
@@ -1,36 +1,33 @@
-SDG_GOAL: '<p>Objectif 2 : Éliminer la faim, assurer la sécurité alimentaire, améliorer
-  la nutrition et promouvoir l’agriculture durable</p>'
-SDG_TARGET: '<p>Cible 2.a : Accroître, notamment grâce au renforcement de la coopération
+SDG_GOAL: 'Objectif 2 : Éliminer la faim, assurer la sécurité alimentaire, améliorer
+  la nutrition et promouvoir l’agriculture durable'
+SDG_TARGET: 'Cible 2.a : Accroître, notamment grâce au renforcement de la coopération
   internationale, l’investissement dans l’infrastructure rurale, les services de recherche
   et de vulgarisation agricoles et la mise au point de technologies et de banques
   de plantes et de gènes d’animaux d’élevage, afin de renforcer les capacités productives
-  agricoles des pays en développement, en particulier des pays les moins avancés.</p>'
-SDG_INDICATOR: '<p>Indicateur 2.a.2 : Total des apports publics (aide publique au
-  développement plus autre apports publics) alloués au secteur agricole.</p>'
-STAT_CONC_DEF: |
-  <strong>Définition : </strong>
+  agricoles des pays en développement, en particulier des pays les moins avancés.'
+SDG_INDICATOR: 'Indicateur 2.a.2 : Total des apports publics (aide publique au
+  développement plus autre apports publics) alloués au secteur agricole.'
+STAT_CONC_DEF: >
+  <strong>Définition : </strong><br>
+  Décaissements bruts du total de l'aide publique au développement (APD) et des autres apports du secteur public du Canada vers le secteur agricole.
   <br><br>
-  Décaissements bruts de l’apport d'aide publique au développement (APD) totale et d’autres flux officiels du Canada vers le secteur agricole.
+  <strong>Concepts : </strong><br>
+  APD : Le Comité d'aide au développement (CAD) définit l'APD comme « les flux vers les pays et territoires figurant sur la liste du CAD des bénéficiaires de l'APD et vers les institutions multilatérales, qui sont
   <br><br>
-  <strong>Concepts : </strong>
+  i) fournis par des agences officielles, y compris les gouvernements des États et des collectivités locales, ou par leurs agences exécutives; et
   <br><br>
-  APD: Le CAD définit l’APD comme "tous les apports de ressources qui sont fournis aux pays et territoires sur la Liste des bénéficiaires d'APD, ou à des institutions multilatérales, et qui répondent aux critères suivants :
-  <br>
-  <ol type="i">
-    <li>émaner d'organismes publics, y compris les États et les collectivités locales, ou d'organismes agissant pour le compte d'organismes publics ;</li>
-    <li>sachant que chaque opération doit en outre :</li>
-      <ol type="a">
-        <li>avoir pour but essentiel de favoriser le développement économique et l'amélioration du niveau de vie des pays en développement ;</li>
-        <li>être assortie de conditions favorables et comporter un élément de libéralité au moins égal à 25 pour cent (sur la base d'un taux d'actualisation de 10 pour cent). (voir https://www.oecd.org/fr/cad/financementpourledeveloppementdurable/normes-financement-developpement/aidepubliqueaudeveloppementdefinitionetchampcouvert.htm)</li>
-      </ol>
-  </ol>
+  ii) chaque transaction est administrée avec pour principal objectif la promotion du développement économique et du bien-être des pays en développement; et
   <br><br>
-  Autres apports du secteur public (AASP) : les AASP (à l'exclusion des crédits à l'exportation bénéficiant d'un soutien public) sont définis comme des opérations du secteur public qui ne satisfont pas aux critères d'éligibilité à l'APD, soit parce qu'elles ne sont pas principalement destinées au développement, soit parce qu'elles sont pas suffisamment assortis. (voir http://www.oecd.org/dac/stats/documentupload/DCDDAC(2016)3FINAL.pdf, Para 24) (voir aussi https://data.oecd.org/fr/drf/autres-apports-du-secteur-public-aasp.htm)
+  iii) est de nature concessionnelle et comporte un élément de subvention d'au moins 25 % (calculé à un taux d'actualisation de 10 %) ». (Consulter http://www.oecd.org/fr/developpement/financementpourledeveloppementdurable/normes-financement-developpement/aidepubliqueaudeveloppementdefinitionetchampcouvert.htm).
   <br><br>
-  Le secteur agricole est tel que défini par le CAD et comprend tous les codes sectoriels de la série 311 du Système de notification des pays créanciers – SNPC. (voir https://www.oecd.org/fr/developpement/financementpourledeveloppementdurable/normes-financement-developpement/codes-objetclassificationsectorielle.htm)
-DATA_COMP: |
+  Autres apports du secteur public : Les autres apports du secteur public (à l'exclusion des crédits à l'exportation bénéficiant d'un soutien public) sont définis comme des transactions du secteur public qui ne remplissent pas les conditions d'éligibilité à l'APD, soit parce qu'elles ne visent pas principalement le développement, soit parce qu'elles ne sont pas suffisamment concessionnelles.
+  <br><br>
+  (Consulter http://www.oecd.org/dac/stats/documentupload/DCDDAC(2016)3FINAL.pdf (en anglais), paragraphe 24)
+  <br><br>
+  Le secteur de l'agriculture est tel que défini par le CAD et comprend tous les codes sectoriels des système de notification des pays créanciers de la série 311 (consulter le lien : http://www.oecd.org/fr/developpement/financementpourledeveloppementdurable/normes-financement-developpement/codes-objetclassificationsectorielle.htm).
+DATA_COMP: >
   Les données étaient disponibles pour rapporter pour cet indicateur comme spécifié dans les métadonnées. Veuillez vous référer aux sources pour obtenir des informations supplémentaires sur les métadonnées ou la source.
-  <br>
+  <br><br>
   Les données proviennent du Système de notification des pays créanciers de l'OCDE. Sélectionnez Donneur = « Canada », Receveur = « Pays en développement », Secteur = « Agriculture », Mesure = « Aide publique au développement » et « AASP (autre que crédits à l'exportation) », Type de flux = « Versements », et Type de prix = « Prix constants ». 
 REC_USE_LIM: '   '
 SDG_GOAL__GLOBAL: '<p>Objectif 2 : Éliminer la faim, assurer la sécurité alimentaire,


### PR DESCRIPTION
- #258 
- improve alignment between EN/FR metadata by taking translations from https://worldbank.github.io/sdg-metadata/metadata/fr/2-a-2/
- further improve alignment between EN/FR metadata by matching formatting and correcting typos
- order ODA values before OOF values in the csv file so that ODA appears first in the disaggregation dropdown menu