### PR TITLE
GRIP 1.5.1/11.5.1/13.1.1, 1.5.2/11.5.2

### DIFF
--- a/data/indicator_1-5-1.csv
+++ b/data/indicator_1-5-1.csv
@@ -1,71 +1,77 @@
-Year,Units,Type of natural disaster,Value
-2015,"Rate per 100,000 population",,50.68
-2016,"Rate per 100,000 population",,264.06
-2017,"Rate per 100,000 population",,197.88
-2018,"Rate per 100,000 population",,43.89
-2019,"Rate per 100,000 population",,63.83
-2020,"Rate per 100,000 population",,35.40
-2015,Number,,18094
-2016,Number,,95351
-2017,Number,,72317
-2018,Number,,16268
-2019,Number,,24001
-2020,Number,,13454
-2015,Number,Meteorological - Flood,1633
-2015,Number,Meteorological - Storm,1
-2015,Number,Meteorological - Tornado,6
-2015,Number,Meteorological - Wildfire,16433
-2015,Number,Meteorological - Winter storm,21
-2016,Number,Meteorological - Flood,1843
-2016,Number,Meteorological - Storm,2
-2016,Number,Meteorological - Tornado,600
-2016,Number,Meteorological - Wildfire,92706
-2016,Number,Meteorological - Winter storm,200
-2017,Number,Meteorological - Flood,7070
-2017,Number,Meteorological - Storm,200
-2017,Number,Meteorological - Wildfire,65000
-2017,Number,Meteorological - Winter storm,47
-2018,Number,Meteorological - Flood,11173
-2018,Number,Meteorological - Heat event,93
-2018,Number,Meteorological - Storm,5
-2018,Number,Meteorological - Tornado,6
-2018,Number,Meteorological - Wildfire,4990
-2018,Number,Meteorological - Winter storm,1
-2019,Number,Meteorological - Flood,12501
-2019,Number,Meteorological - Hurricane,0
-2019,Number,Meteorological - Storm,0
-2019,Number,Meteorological - Wildfire,5500
-2019,Number,Meteorological - Winter storm,6000
-2020,Number,Meteorological - Flood,13452
-2020,Number,Meteorological - Storm,0
-2020,Number,Meteorological - Wildfire,0
-2020,Number,Meteorological - Winter storm,2
-2015,"Rate per 100,000 population",Meteorological - Flood,4.574
-2015,"Rate per 100,000 population",Meteorological - Storm,0.003
-2015,"Rate per 100,000 population",Meteorological - Tornado,0.017
-2015,"Rate per 100,000 population",Meteorological - Wildfire,46.027
-2015,"Rate per 100,000 population",Meteorological - Winter storm,0.059
-2016,"Rate per 100,000 population",Meteorological - Flood,5.104
-2016,"Rate per 100,000 population",Meteorological - Storm,0.006
-2016,"Rate per 100,000 population",Meteorological - Tornado,1.662
-2016,"Rate per 100,000 population",Meteorological - Wildfire,256.736
-2016,"Rate per 100,000 population",Meteorological - Winter storm,0.554
-2017,"Rate per 100,000 population",Meteorological - Flood,19.346
-2017,"Rate per 100,000 population",Meteorological - Storm,0.547
-2017,"Rate per 100,000 population",Meteorological - Wildfire,177.862
-2017,"Rate per 100,000 population",Meteorological - Winter storm,0.129
-2018,"Rate per 100,000 population",Meteorological - Flood,30.144
-2018,"Rate per 100,000 population",Meteorological - Heat event,0.251
-2018,"Rate per 100,000 population",Meteorological - Storm,0.013
-2018,"Rate per 100,000 population",Meteorological - Tornado,0.016
-2018,"Rate per 100,000 population",Meteorological - Wildfire,13.463
-2018,"Rate per 100,000 population",Meteorological - Winter storm,0.003
-2019,"Rate per 100,000 population",Meteorological - Flood, 33.246
-2019,"Rate per 100,000 population",Meteorological - Hurricane,0
-2019,"Rate per 100,000 population",Meteorological - Storm,0
-2019,"Rate per 100,000 population",Meteorological - Wildfire,14.627
-2019,"Rate per 100,000 population",Meteorological - Winter storm,15.957
-2020,"Rate per 100,000 population",Meteorological - Flood,0
-2020,"Rate per 100,000 population",Meteorological - Storm,0
-2020,"Rate per 100,000 population",Meteorological - Wildfire,0
-2020,"Rate per 100,000 population",Meteorological - Winter storm,0.005
+"Year","Units","Type of natural disaster","Value"
+"2020","Number","Storm - Unspecified / Other",0
+"2020","Number","Wildfire",0
+"2020","Number","Storms and Severe Thunderstorms",0
+"2020","Number","Flood",13452
+"2020","Number","Winter Storm",2
+"2019","Number","Storm - Unspecified / Other",0
+"2019","Number","Winter Storm",6000
+"2019","Number","Hurricane / Typhoon / Tropical Storm",0
+"2019","Number","Storms and Severe Thunderstorms",0
+"2019","Number","Wildfire",5500
+"2019","Number","Flood",12501
+"2018","Number","Storms and Severe Thunderstorms",2
+"2018","Number","Tornado",6
+"2018","Number","Wildfire",4990
+"2018","Number","Flood",11173
+"2018","Number","Heat Event",93
+"2018","Number","Storm - Unspecified / Other",3
+"2018","Number","Winter Storm",1
+"2017","Number","Storm - Unspecified / Other",200
+"2017","Number","Wildfire",65000
+"2017","Number","Flood",7070
+"2017","Number","Winter Storm",47
+"2016","Number","Storm - Unspecified / Other",2
+"2016","Number","Winter Storm",200
+"2016","Number","Flood",1843
+"2016","Number","Wildfire",92706
+"2016","Number","Tornado",600
+"2015","Number","Storm - Unspecified / Other",1
+"2015","Number","Tornado",6
+"2015","Number","Flood",1633
+"2015","Number","Wildfire",16433
+"2015","Number","Winter Storm",21
+"2020","Number",,13454
+"2019","Number",,24001
+"2018","Number",,16268
+"2017","Number",,72317
+"2016","Number",,95351
+"2015","Number",,18094
+"2020","Rate per 100,000 population","Storm - Unspecified / Other",0
+"2020","Rate per 100,000 population","Wildfire",0
+"2020","Rate per 100,000 population","Storms and Severe Thunderstorms",0
+"2020","Rate per 100,000 population","Flood",35.373341532768
+"2020","Rate per 100,000 population","Winter Storm",0.00525919439975736
+"2019","Rate per 100,000 population","Storm - Unspecified / Other",0
+"2019","Rate per 100,000 population","Winter Storm",15.949601386233
+"2019","Rate per 100,000 population","Hurricane / Typhoon / Tropical Storm",0
+"2019","Rate per 100,000 population","Storms and Severe Thunderstorms",0
+"2019","Rate per 100,000 population","Wildfire",14.6204679373803
+"2019","Rate per 100,000 population","Flood",33.2309944882165
+"2018","Rate per 100,000 population","Storms and Severe Thunderstorms",0.00539481698353124
+"2018","Rate per 100,000 population","Tornado",0.0161844509505937
+"2018","Rate per 100,000 population","Wildfire",13.4600683739104
+"2018","Rate per 100,000 population","Flood",30.1381450784973
+"2018","Rate per 100,000 population","Heat Event",0.250858989734203
+"2018","Rate per 100,000 population","Storm - Unspecified / Other",0.00809222547529686
+"2018","Rate per 100,000 population","Winter Storm",0.00269740849176562
+"2017","Rate per 100,000 population","Storm - Unspecified / Other",0.547269365297513
+"2017","Rate per 100,000 population","Wildfire",177.862543721692
+"2017","Rate per 100,000 population","Flood",19.3459720632671
+"2017","Rate per 100,000 population","Winter Storm",0.128608300844915
+"2016","Rate per 100,000 population","Storm - Unspecified / Other",0.00553850879472273
+"2016","Rate per 100,000 population","Winter Storm",0.553850879472273
+"2016","Rate per 100,000 population","Flood",5.103735854337
+"2016","Rate per 100,000 population","Wildfire",256.726498161783
+"2016","Rate per 100,000 population","Tornado",1.66155263841682
+"2015","Rate per 100,000 population","Storm - Unspecified / Other",0.00280076756715638
+"2015","Rate per 100,000 population","Tornado",0.0168046054029383
+"2015","Rate per 100,000 population","Flood",4.57365343716638
+"2015","Rate per 100,000 population","Wildfire",46.0250134310809
+"2015","Rate per 100,000 population","Winter Storm",0.0588161189102841
+"2020","Rate per 100,000 population",,35.3786007271678
+"2019","Rate per 100,000 population",,63.8010638118298
+"2018","Rate per 100,000 population",,43.8814413440431
+"2017","Rate per 100,000 population",,197.884393451101
+"2016","Rate per 100,000 population",,264.051176042804
+"2015","Rate per 100,000 population",,50.6770883601276

--- a/data/indicator_1-5-2.csv
+++ b/data/indicator_1-5-2.csv
@@ -1,31 +1,44 @@
-"Year","Units","Type of natural disaster","Value"
-2015,"Percentage (%)",,0.024
-2016,"Percentage (%)",,0.2503
-2017,"Percentage (%)",,0.025
-2018,"Percentage (%)",,0.064
-2019,"Percentage (%)",,0.007
-2020,"Percentage (%)",,0
-2015,"Percentage (%)","Meteorological - Flood",0.019
-2015,"Percentage (%)","Meteorological - Storm",0.006
-2016,"Percentage (%)","Meteorological - Flood",0.0275
-2016,"Percentage (%)","Meteorological - Storm",0.0197
-2016,"Percentage (%)","Meteorological - Wildfire",0.2009
-2016,"Percentage (%)","Meteorological - Winter storm",0.0014
-2016,"Percentage (%)","Meteorological - Epidemic",0.0008
-2017,"Percentage (%)","Meteorological - Flood",0.014
-2017,"Percentage (%)","Meteorological - Storm",0.002
-2017,"Percentage (%)","Meteorological - Wildfire",0.006
-2017,"Percentage (%)","Meteorological - Winter storm",0.003
-2018,"Percentage (%)","Meteorological - Flood",0.004
-2018,"Percentage (%)","Meteorological - Tornado",0.015
-2018,"Percentage (%)","Meteorological - Storm",0.037
-2018,"Percentage (%)","Meteorological - Wildfire",0
-2018,"Percentage (%)","Meteorological - Winter storm",0.008
-2019,"Percentage (%)","Meteorological - Flood",0
-2019,"Percentage (%)","Meteorological - Storm",0
-2019,"Percentage (%)","Meteorological - Wildfire",0
-2019,"Percentage (%)","Meteorological - Winter storm",0.007
-2020,"Percentage (%)","Meteorological - Flood",0
-2020,"Percentage (%)","Meteorological - Storm",0
-2020,"Percentage (%)","Meteorological - Wildfire",0
-2020,"Percentage (%)","Meteorological - Winter storm",0
+"Year","Type of natural disaster","Value"
+"2020","Storm - Unspecified / Other",
+"2020","Wildfire",
+"2020","Storms and Severe Thunderstorms",
+"2020","Flood",
+"2020","Winter Storm",
+"2019","Storm - Unspecified / Other",
+"2019","Winter Storm",0.00704541004502579
+"2019","Hurricane / Typhoon / Tropical Storm",
+"2019","Storms and Severe Thunderstorms",
+"2019","Wildfire",
+"2019","Flood",0
+"2018","Storms and Severe Thunderstorms",0.00683305936685788
+"2018","Tornado",0.0149395596408244
+"2018","Wildfire",0
+"2018","Flood",0.0035783376385208
+"2018","Heat Event",0
+"2018","Storm - Unspecified / Other",0.0304158699274268
+"2018","Winter Storm",0.00849855189148691
+"2017","Storm - Unspecified / Other",
+"2017","Wildfire",0.0060729473087734
+"2017","Flood",0.0135006290171963
+"2017","Storms and Severe Thunderstorms",0.00214888904771982
+"2017","Winter Storm",0.00280289875789542
+"2016","Storm - Unspecified / Other",0
+"2016","Winter Storm",0.0013516922689561
+"2016","Flood",0.0275487710654222
+"2016","Epidemic",0.000824473534152705
+"2016","Wildfire",0.200869301196968
+"2016","Tornado",0
+"2016","Storms and Severe Thunderstorms",0.0197048187269043
+"2016","Landslide",0
+"2015","Storm - Unspecified / Other",0.00174674858486134
+"2015","Storms and Severe Thunderstorms",0.0170959099013736
+"2015","Tornado",0
+"2015","Flood",0
+"2015","Wildfire",0.00565663589124219
+"2015","Winter Storm",0
+"2020",,
+"2019",,0.00704541004502579
+"2018",,0.0642653784651168
+"2017",,0.0245253641315849
+"2016",,0.250299056792403
+"2015",,0.0244992943774772

--- a/data/indicator_11-5-1.csv
+++ b/data/indicator_11-5-1.csv
@@ -1,71 +1,77 @@
-Year,Units,Type of natural disaster,Value
-2015,"Rate per 100,000 population",,50.68
-2016,"Rate per 100,000 population",,264.06
-2017,"Rate per 100,000 population",,197.88
-2018,"Rate per 100,000 population",,43.89
-2019,"Rate per 100,000 population",,63.83
-2020,"Rate per 100,000 population",,35.40
-2015,Number,,18094
-2016,Number,,95351
-2017,Number,,72317
-2018,Number,,16268
-2019,Number,,24001
-2020,Number,,13454
-2015,Number,Meteorological - Flood,1633
-2015,Number,Meteorological - Storm,1
-2015,Number,Meteorological - Tornado,6
-2015,Number,Meteorological - Wildfire,16433
-2015,Number,Meteorological - Winter storm,21
-2016,Number,Meteorological - Flood,1843
-2016,Number,Meteorological - Storm,2
-2016,Number,Meteorological - Tornado,600
-2016,Number,Meteorological - Wildfire,92706
-2016,Number,Meteorological - Winter storm,200
-2017,Number,Meteorological - Flood,7070
-2017,Number,Meteorological - Storm,200
-2017,Number,Meteorological - Wildfire,65000
-2017,Number,Meteorological - Winter storm,47
-2018,Number,Meteorological - Flood,11173
-2018,Number,Meteorological - Heat event,93
-2018,Number,Meteorological - Storm,5
-2018,Number,Meteorological - Tornado,6
-2018,Number,Meteorological - Wildfire,4990
-2018,Number,Meteorological - Winter storm,1
-2019,Number,Meteorological - Flood,12501
-2019,Number,Meteorological - Hurricane,0
-2019,Number,Meteorological - Storm,0
-2019,Number,Meteorological - Wildfire,5500
-2019,Number,Meteorological - Winter storm,6000
-2020,Number,Meteorological - Flood,13452
-2020,Number,Meteorological - Storm,0
-2020,Number,Meteorological - Wildfire,0
-2020,Number,Meteorological - Winter storm,2
-2015,"Rate per 100,000 population",Meteorological - Flood,4.574
-2015,"Rate per 100,000 population",Meteorological - Storm,0.003
-2015,"Rate per 100,000 population",Meteorological - Tornado,0.017
-2015,"Rate per 100,000 population",Meteorological - Wildfire,46.027
-2015,"Rate per 100,000 population",Meteorological - Winter storm,0.059
-2016,"Rate per 100,000 population",Meteorological - Flood,5.104
-2016,"Rate per 100,000 population",Meteorological - Storm,0.006
-2016,"Rate per 100,000 population",Meteorological - Tornado,1.662
-2016,"Rate per 100,000 population",Meteorological - Wildfire,256.736
-2016,"Rate per 100,000 population",Meteorological - Winter storm,0.554
-2017,"Rate per 100,000 population",Meteorological - Flood,19.346
-2017,"Rate per 100,000 population",Meteorological - Storm,0.547
-2017,"Rate per 100,000 population",Meteorological - Wildfire,177.862
-2017,"Rate per 100,000 population",Meteorological - Winter storm,0.129
-2018,"Rate per 100,000 population",Meteorological - Flood,30.144
-2018,"Rate per 100,000 population",Meteorological - Heat event,0.251
-2018,"Rate per 100,000 population",Meteorological - Storm,0.013
-2018,"Rate per 100,000 population",Meteorological - Tornado,0.016
-2018,"Rate per 100,000 population",Meteorological - Wildfire,13.463
-2018,"Rate per 100,000 population",Meteorological - Winter storm,0.003
-2019,"Rate per 100,000 population",Meteorological - Flood, 33.246
-2019,"Rate per 100,000 population",Meteorological - Hurricane,0
-2019,"Rate per 100,000 population",Meteorological - Storm,0
-2019,"Rate per 100,000 population",Meteorological - Wildfire,14.627
-2019,"Rate per 100,000 population",Meteorological - Winter storm,15.957
-2020,"Rate per 100,000 population",Meteorological - Flood,0
-2020,"Rate per 100,000 population",Meteorological - Storm,0
-2020,"Rate per 100,000 population",Meteorological - Wildfire,0
-2020,"Rate per 100,000 population",Meteorological - Winter storm,0.005
+"Year","Units","Type of natural disaster","Value"
+"2020","Number","Storm - Unspecified / Other",0
+"2020","Number","Wildfire",0
+"2020","Number","Storms and Severe Thunderstorms",0
+"2020","Number","Flood",13452
+"2020","Number","Winter Storm",2
+"2019","Number","Storm - Unspecified / Other",0
+"2019","Number","Winter Storm",6000
+"2019","Number","Hurricane / Typhoon / Tropical Storm",0
+"2019","Number","Storms and Severe Thunderstorms",0
+"2019","Number","Wildfire",5500
+"2019","Number","Flood",12501
+"2018","Number","Storms and Severe Thunderstorms",2
+"2018","Number","Tornado",6
+"2018","Number","Wildfire",4990
+"2018","Number","Flood",11173
+"2018","Number","Heat Event",93
+"2018","Number","Storm - Unspecified / Other",3
+"2018","Number","Winter Storm",1
+"2017","Number","Storm - Unspecified / Other",200
+"2017","Number","Wildfire",65000
+"2017","Number","Flood",7070
+"2017","Number","Winter Storm",47
+"2016","Number","Storm - Unspecified / Other",2
+"2016","Number","Winter Storm",200
+"2016","Number","Flood",1843
+"2016","Number","Wildfire",92706
+"2016","Number","Tornado",600
+"2015","Number","Storm - Unspecified / Other",1
+"2015","Number","Tornado",6
+"2015","Number","Flood",1633
+"2015","Number","Wildfire",16433
+"2015","Number","Winter Storm",21
+"2020","Number",,13454
+"2019","Number",,24001
+"2018","Number",,16268
+"2017","Number",,72317
+"2016","Number",,95351
+"2015","Number",,18094
+"2020","Rate per 100,000 population","Storm - Unspecified / Other",0
+"2020","Rate per 100,000 population","Wildfire",0
+"2020","Rate per 100,000 population","Storms and Severe Thunderstorms",0
+"2020","Rate per 100,000 population","Flood",35.373341532768
+"2020","Rate per 100,000 population","Winter Storm",0.00525919439975736
+"2019","Rate per 100,000 population","Storm - Unspecified / Other",0
+"2019","Rate per 100,000 population","Winter Storm",15.949601386233
+"2019","Rate per 100,000 population","Hurricane / Typhoon / Tropical Storm",0
+"2019","Rate per 100,000 population","Storms and Severe Thunderstorms",0
+"2019","Rate per 100,000 population","Wildfire",14.6204679373803
+"2019","Rate per 100,000 population","Flood",33.2309944882165
+"2018","Rate per 100,000 population","Storms and Severe Thunderstorms",0.00539481698353124
+"2018","Rate per 100,000 population","Tornado",0.0161844509505937
+"2018","Rate per 100,000 population","Wildfire",13.4600683739104
+"2018","Rate per 100,000 population","Flood",30.1381450784973
+"2018","Rate per 100,000 population","Heat Event",0.250858989734203
+"2018","Rate per 100,000 population","Storm - Unspecified / Other",0.00809222547529686
+"2018","Rate per 100,000 population","Winter Storm",0.00269740849176562
+"2017","Rate per 100,000 population","Storm - Unspecified / Other",0.547269365297513
+"2017","Rate per 100,000 population","Wildfire",177.862543721692
+"2017","Rate per 100,000 population","Flood",19.3459720632671
+"2017","Rate per 100,000 population","Winter Storm",0.128608300844915
+"2016","Rate per 100,000 population","Storm - Unspecified / Other",0.00553850879472273
+"2016","Rate per 100,000 population","Winter Storm",0.553850879472273
+"2016","Rate per 100,000 population","Flood",5.103735854337
+"2016","Rate per 100,000 population","Wildfire",256.726498161783
+"2016","Rate per 100,000 population","Tornado",1.66155263841682
+"2015","Rate per 100,000 population","Storm - Unspecified / Other",0.00280076756715638
+"2015","Rate per 100,000 population","Tornado",0.0168046054029383
+"2015","Rate per 100,000 population","Flood",4.57365343716638
+"2015","Rate per 100,000 population","Wildfire",46.0250134310809
+"2015","Rate per 100,000 population","Winter Storm",0.0588161189102841
+"2020","Rate per 100,000 population",,35.3786007271678
+"2019","Rate per 100,000 population",,63.8010638118298
+"2018","Rate per 100,000 population",,43.8814413440431
+"2017","Rate per 100,000 population",,197.884393451101
+"2016","Rate per 100,000 population",,264.051176042804
+"2015","Rate per 100,000 population",,50.6770883601276

--- a/data/indicator_11-5-2.csv
+++ b/data/indicator_11-5-2.csv
@@ -1,31 +1,44 @@
-"Year","Units","Type of natural disaster","Value"
-2015,"Percentage (%)",,0.024
-2016,"Percentage (%)",,0.2503
-2017,"Percentage (%)",,0.025
-2018,"Percentage (%)",,0.064
-2019,"Percentage (%)",,0.007
-2020,"Percentage (%)",,0
-2015,"Percentage (%)","Meteorological - Flood",0.019
-2015,"Percentage (%)","Meteorological - Storm",0.006
-2016,"Percentage (%)","Meteorological - Flood",0.0275
-2016,"Percentage (%)","Meteorological - Storm",0.0197
-2016,"Percentage (%)","Meteorological - Wildfire",0.2009
-2016,"Percentage (%)","Meteorological - Winter storm",0.0014
-2016,"Percentage (%)","Meteorological - Epidemic",0.0008
-2017,"Percentage (%)","Meteorological - Flood",0.014
-2017,"Percentage (%)","Meteorological - Storm",0.002
-2017,"Percentage (%)","Meteorological - Wildfire",0.006
-2017,"Percentage (%)","Meteorological - Winter storm",0.003
-2018,"Percentage (%)","Meteorological - Flood",0.004
-2018,"Percentage (%)","Meteorological - Tornado",0.015
-2018,"Percentage (%)","Meteorological - Storm",0.037
-2018,"Percentage (%)","Meteorological - Wildfire",0
-2018,"Percentage (%)","Meteorological - Winter storm",0.008
-2019,"Percentage (%)","Meteorological - Flood",0
-2019,"Percentage (%)","Meteorological - Storm",0
-2019,"Percentage (%)","Meteorological - Wildfire",0
-2019,"Percentage (%)","Meteorological - Winter storm",0.007
-2020,"Percentage (%)","Meteorological - Flood",0
-2020,"Percentage (%)","Meteorological - Storm",0
-2020,"Percentage (%)","Meteorological - Wildfire",0
-2020,"Percentage (%)","Meteorological - Winter storm",0
+"Year","Type of natural disaster","Value"
+"2020","Storm - Unspecified / Other",
+"2020","Wildfire",
+"2020","Storms and Severe Thunderstorms",
+"2020","Flood",
+"2020","Winter Storm",
+"2019","Storm - Unspecified / Other",
+"2019","Winter Storm",0.00704541004502579
+"2019","Hurricane / Typhoon / Tropical Storm",
+"2019","Storms and Severe Thunderstorms",
+"2019","Wildfire",
+"2019","Flood",0
+"2018","Storms and Severe Thunderstorms",0.00683305936685788
+"2018","Tornado",0.0149395596408244
+"2018","Wildfire",0
+"2018","Flood",0.0035783376385208
+"2018","Heat Event",0
+"2018","Storm - Unspecified / Other",0.0304158699274268
+"2018","Winter Storm",0.00849855189148691
+"2017","Storm - Unspecified / Other",
+"2017","Wildfire",0.0060729473087734
+"2017","Flood",0.0135006290171963
+"2017","Storms and Severe Thunderstorms",0.00214888904771982
+"2017","Winter Storm",0.00280289875789542
+"2016","Storm - Unspecified / Other",0
+"2016","Winter Storm",0.0013516922689561
+"2016","Flood",0.0275487710654222
+"2016","Epidemic",0.000824473534152705
+"2016","Wildfire",0.200869301196968
+"2016","Tornado",0
+"2016","Storms and Severe Thunderstorms",0.0197048187269043
+"2016","Landslide",0
+"2015","Storm - Unspecified / Other",0.00174674858486134
+"2015","Storms and Severe Thunderstorms",0.0170959099013736
+"2015","Tornado",0
+"2015","Flood",0
+"2015","Wildfire",0.00565663589124219
+"2015","Winter Storm",0
+"2020",,
+"2019",,0.00704541004502579
+"2018",,0.0642653784651168
+"2017",,0.0245253641315849
+"2016",,0.250299056792403
+"2015",,0.0244992943774772

--- a/data/indicator_13-1-1.csv
+++ b/data/indicator_13-1-1.csv
@@ -1,71 +1,77 @@
-Year,Units,Type of natural disaster,Value
-2015,"Rate per 100,000 population",,50.68
-2016,"Rate per 100,000 population",,264.06
-2017,"Rate per 100,000 population",,197.88
-2018,"Rate per 100,000 population",,43.89
-2019,"Rate per 100,000 population",,63.83
-2020,"Rate per 100,000 population",,35.40
-2015,Number,,18094
-2016,Number,,95351
-2017,Number,,72317
-2018,Number,,16268
-2019,Number,,24001
-2020,Number,,13454
-2015,Number,Meteorological - Flood,1633
-2015,Number,Meteorological - Storm,1
-2015,Number,Meteorological - Tornado,6
-2015,Number,Meteorological - Wildfire,16433
-2015,Number,Meteorological - Winter storm,21
-2016,Number,Meteorological - Flood,1843
-2016,Number,Meteorological - Storm,2
-2016,Number,Meteorological - Tornado,600
-2016,Number,Meteorological - Wildfire,92706
-2016,Number,Meteorological - Winter storm,200
-2017,Number,Meteorological - Flood,7070
-2017,Number,Meteorological - Storm,200
-2017,Number,Meteorological - Wildfire,65000
-2017,Number,Meteorological - Winter storm,47
-2018,Number,Meteorological - Flood,11173
-2018,Number,Meteorological - Heat event,93
-2018,Number,Meteorological - Storm,5
-2018,Number,Meteorological - Tornado,6
-2018,Number,Meteorological - Wildfire,4990
-2018,Number,Meteorological - Winter storm,1
-2019,Number,Meteorological - Flood,12501
-2019,Number,Meteorological - Hurricane,0
-2019,Number,Meteorological - Storm,0
-2019,Number,Meteorological - Wildfire,5500
-2019,Number,Meteorological - Winter storm,6000
-2020,Number,Meteorological - Flood,13452
-2020,Number,Meteorological - Storm,0
-2020,Number,Meteorological - Wildfire,0
-2020,Number,Meteorological - Winter storm,2
-2015,"Rate per 100,000 population",Meteorological - Flood,4.574
-2015,"Rate per 100,000 population",Meteorological - Storm,0.003
-2015,"Rate per 100,000 population",Meteorological - Tornado,0.017
-2015,"Rate per 100,000 population",Meteorological - Wildfire,46.027
-2015,"Rate per 100,000 population",Meteorological - Winter storm,0.059
-2016,"Rate per 100,000 population",Meteorological - Flood,5.104
-2016,"Rate per 100,000 population",Meteorological - Storm,0.006
-2016,"Rate per 100,000 population",Meteorological - Tornado,1.662
-2016,"Rate per 100,000 population",Meteorological - Wildfire,256.736
-2016,"Rate per 100,000 population",Meteorological - Winter storm,0.554
-2017,"Rate per 100,000 population",Meteorological - Flood,19.346
-2017,"Rate per 100,000 population",Meteorological - Storm,0.547
-2017,"Rate per 100,000 population",Meteorological - Wildfire,177.862
-2017,"Rate per 100,000 population",Meteorological - Winter storm,0.129
-2018,"Rate per 100,000 population",Meteorological - Flood,30.144
-2018,"Rate per 100,000 population",Meteorological - Heat event,0.251
-2018,"Rate per 100,000 population",Meteorological - Storm,0.013
-2018,"Rate per 100,000 population",Meteorological - Tornado,0.016
-2018,"Rate per 100,000 population",Meteorological - Wildfire,13.463
-2018,"Rate per 100,000 population",Meteorological - Winter storm,0.003
-2019,"Rate per 100,000 population",Meteorological - Flood, 33.246
-2019,"Rate per 100,000 population",Meteorological - Hurricane,0
-2019,"Rate per 100,000 population",Meteorological - Storm,0
-2019,"Rate per 100,000 population",Meteorological - Wildfire,14.627
-2019,"Rate per 100,000 population",Meteorological - Winter storm,15.957
-2020,"Rate per 100,000 population",Meteorological - Flood,0
-2020,"Rate per 100,000 population",Meteorological - Storm,0
-2020,"Rate per 100,000 population",Meteorological - Wildfire,0
-2020,"Rate per 100,000 population",Meteorological - Winter storm
+"Year","Units","Type of natural disaster","Value"
+"2020","Number","Storm - Unspecified / Other",0
+"2020","Number","Wildfire",0
+"2020","Number","Storms and Severe Thunderstorms",0
+"2020","Number","Flood",13452
+"2020","Number","Winter Storm",2
+"2019","Number","Storm - Unspecified / Other",0
+"2019","Number","Winter Storm",6000
+"2019","Number","Hurricane / Typhoon / Tropical Storm",0
+"2019","Number","Storms and Severe Thunderstorms",0
+"2019","Number","Wildfire",5500
+"2019","Number","Flood",12501
+"2018","Number","Storms and Severe Thunderstorms",2
+"2018","Number","Tornado",6
+"2018","Number","Wildfire",4990
+"2018","Number","Flood",11173
+"2018","Number","Heat Event",93
+"2018","Number","Storm - Unspecified / Other",3
+"2018","Number","Winter Storm",1
+"2017","Number","Storm - Unspecified / Other",200
+"2017","Number","Wildfire",65000
+"2017","Number","Flood",7070
+"2017","Number","Winter Storm",47
+"2016","Number","Storm - Unspecified / Other",2
+"2016","Number","Winter Storm",200
+"2016","Number","Flood",1843
+"2016","Number","Wildfire",92706
+"2016","Number","Tornado",600
+"2015","Number","Storm - Unspecified / Other",1
+"2015","Number","Tornado",6
+"2015","Number","Flood",1633
+"2015","Number","Wildfire",16433
+"2015","Number","Winter Storm",21
+"2020","Number",,13454
+"2019","Number",,24001
+"2018","Number",,16268
+"2017","Number",,72317
+"2016","Number",,95351
+"2015","Number",,18094
+"2020","Rate per 100,000 population","Storm - Unspecified / Other",0
+"2020","Rate per 100,000 population","Wildfire",0
+"2020","Rate per 100,000 population","Storms and Severe Thunderstorms",0
+"2020","Rate per 100,000 population","Flood",35.373341532768
+"2020","Rate per 100,000 population","Winter Storm",0.00525919439975736
+"2019","Rate per 100,000 population","Storm - Unspecified / Other",0
+"2019","Rate per 100,000 population","Winter Storm",15.949601386233
+"2019","Rate per 100,000 population","Hurricane / Typhoon / Tropical Storm",0
+"2019","Rate per 100,000 population","Storms and Severe Thunderstorms",0
+"2019","Rate per 100,000 population","Wildfire",14.6204679373803
+"2019","Rate per 100,000 population","Flood",33.2309944882165
+"2018","Rate per 100,000 population","Storms and Severe Thunderstorms",0.00539481698353124
+"2018","Rate per 100,000 population","Tornado",0.0161844509505937
+"2018","Rate per 100,000 population","Wildfire",13.4600683739104
+"2018","Rate per 100,000 population","Flood",30.1381450784973
+"2018","Rate per 100,000 population","Heat Event",0.250858989734203
+"2018","Rate per 100,000 population","Storm - Unspecified / Other",0.00809222547529686
+"2018","Rate per 100,000 population","Winter Storm",0.00269740849176562
+"2017","Rate per 100,000 population","Storm - Unspecified / Other",0.547269365297513
+"2017","Rate per 100,000 population","Wildfire",177.862543721692
+"2017","Rate per 100,000 population","Flood",19.3459720632671
+"2017","Rate per 100,000 population","Winter Storm",0.128608300844915
+"2016","Rate per 100,000 population","Storm - Unspecified / Other",0.00553850879472273
+"2016","Rate per 100,000 population","Winter Storm",0.553850879472273
+"2016","Rate per 100,000 population","Flood",5.103735854337
+"2016","Rate per 100,000 population","Wildfire",256.726498161783
+"2016","Rate per 100,000 population","Tornado",1.66155263841682
+"2015","Rate per 100,000 population","Storm - Unspecified / Other",0.00280076756715638
+"2015","Rate per 100,000 population","Tornado",0.0168046054029383
+"2015","Rate per 100,000 population","Flood",4.57365343716638
+"2015","Rate per 100,000 population","Wildfire",46.0250134310809
+"2015","Rate per 100,000 population","Winter Storm",0.0588161189102841
+"2020","Rate per 100,000 population",,35.3786007271678
+"2019","Rate per 100,000 population",,63.8010638118298
+"2018","Rate per 100,000 population",,43.8814413440431
+"2017","Rate per 100,000 population",,197.884393451101
+"2016","Rate per 100,000 population",,264.051176042804
+"2015","Rate per 100,000 population",,50.6770883601276

--- a/indicator-config/1-5-2.yml
+++ b/indicator-config/1-5-2.yml
@@ -19,7 +19,8 @@ graph_stacked_disaggregation: ''
 graph_title: proxy.1-5-2-title
 graph_titles: []
 graph_type: line
-indicator_name: proxy.1-5-2-title
+indicator_name: global_indicators.1-5-2-title
+indicator_available: proxy.1-5-2-title
 indicator_number: 1.5.2
 national_geographical_coverage: Canada
 page_content: ''
@@ -32,4 +33,3 @@ sort: ''
 standalone: false
 tags:
   - Proxy
-"\xEF\xBB\xBFcomposite_breakdown_label": ''

--- a/indicator-config/11-5-2.yml
+++ b/indicator-config/11-5-2.yml
@@ -19,7 +19,8 @@ graph_stacked_disaggregation: ''
 graph_title: proxy.11-5-2-title
 graph_titles: []
 graph_type: line
-indicator_name: proxy.11-5-2-title
+indicator_name: global_indicators.11-5-2-title
+indicator_available: proxy.11-5-2-title
 indicator_number: '11.5.2'
 national_geographical_coverage: Canada
 page_content: ''
@@ -32,4 +33,3 @@ sort: ''
 standalone: false
 tags:
   - Proxy
-"\xEF\xBB\xBFcomposite_breakdown_label": ''

--- a/meta/1-5-1.yml
+++ b/meta/1-5-1.yml
@@ -1,40 +1,52 @@
+# National
 SDG_GOAL: '<p>Goal 1: End poverty in all its forms everywhere</p>'
-SDG_TARGET: '<p>Target 1.5: By 2030, build the resilience of the poor and those in vulnerable
-  situations and reduce their exposure and vulnerability to climate-related extreme
-  events and other economic, social and environmental shocks and disasters</p>'
-SDG_INDICATOR: '<p>Indicator 1.5.1: Number of deaths, missing persons and directly affected
-  persons attributed to disasters per 100,000 population</p>'
-STAT_CONC_DEF: '<strong>Definition:</strong> <br>This indicator measures the number of people who died, went missing or
-  were directly affected by disasters per 100,000 population.<br><br><strong>Concepts:</strong><br> Death: The number of people who died during the disaster, or directly after, as a direct result of the 
-  hazardous event. <br><br> Missing: The number of people whose whereabouts is unknown since the hazardous event. It includes people who are presumed dead, for whom there is no physical evidence such as a body, and for which an official/legal report has been filed with competent authorities.<br><br> Directly affected: The number of people who have suffered injury, illness or other health effects; who were evacuated, displaced, relocated or have suffered direct damage to their livelihoods, economic, physical, social, cultural and environmental assets. Indirectly affected are people who have suffered consequences, other than or in addition to direct effects, over time, due to disruption or changes in economy, critical infrastructure, basic services, commerce or work, or social, health and psychological consequences. <br><br>
-  The Canadian Disaster Database (CDD) tracks significant disaster events that conform to the Emergency Management Framework for Canada definition of a disaster and meet one or more of the following criteria:
-  <br> - 10 or more people killed;
-  <br> - 100 or more people affected/injured/infected/evacuated or homeless;
-  <br> - an appeal for national/international assistance;
-  <br> - historical significance;
-  <br> - significant damage/interruption of normal processes such that the community affected cannot recover on its own. (Public Safety Canada)'
-DATA_COMP: '((Number of deaths, missing persons and directly affected persons attributed to disasters) / Population) x 100,000 = Rate per 100,000 population'
-REC_USE_LIM: 'It is important to note that the Canadian Disaster Database may not be suitable for comparative analysis because of differences in jurisdictional responsibilities, the type of data that is available, and how it is collected and used over time.
-  <br><br> The information contained in the Canadian Disaster Database is based on information that is sourced from outside parties and may not be accurate and should therefore be interpreted with caution. (Public Safety Canada)'
+SDG_TARGET: >-
+  Target 1.5: By 2030, build the resilience of the poor and those in vulnerable situations and reduce their exposure and vulnerability to climate-related extreme events and other economic, social and environmental shocks and disasters
+SDG_INDICATOR: >-
+  Indicator 1.5.1: Number of deaths, missing persons and directly affected persons attributed to disasters per 100,000 population
+STAT_CONC_DEF: >-
+  <p><strong>Definition:</strong><br>
+  This indicator measures the number of people who died, went missing or were directly affected by disasters per 100,000 population.</p>
+  <p><strong>Concepts:</strong><br>
+  Death: The number of people who died during the disaster, or directly after, as a direct result of the hazardous event.
+  <br><br>
+  Missing: The number of people whose whereabouts is unknown since the hazardous event. It includes people who are presumed dead, for whom there is no physical evidence such as a body, and for which an official/legal report has been filed with competent authorities.
+  <br><br>
+  Directly affected: The number of people who have suffered injury, illness or other health effects; who were evacuated, displaced, relocated or have suffered direct damage to their livelihoods, economic, physical, social, cultural and environmental assets. Indirectly affected are people who have suffered consequences, other than or in addition to direct effects, over time, due to disruption or changes in economy, critical infrastructure, basic services, commerce or work, or social, health and psychological consequences.</p>
+  <p>The Canadian Disaster Database (CDD) tracks significant disaster events that conform to the Emergency Management Framework for Canada definition of a disaster and meet one or more of the following criteria:</p>
+  <ul>
+  <li>10 or more people killed;</li>
+  <li>100 or more people affected/injured/infected/evacuated or homeless;</li>
+  <li>an appeal for national/international assistance;</li>
+  <li>historical significance;</li>
+  <li>significant damage/interruption of normal processes such that the community affected cannot recover on its own. (Public Safety Canada)</li>
+  </ul>
+DATA_COMP: >-
+  Number of deaths, missing persons and directly affected persons attributed to disasters) / Population × 100,000 = Rate per 100,000 population
+REC_USE_LIM: >-
+  It is important to note that the Canadian Disaster Database may not be suitable for comparative analysis because of differences in jurisdictional responsibilities, the type of data that is available, and how it is collected and used over time.
+  <br><br>
+  The information contained in the Canadian Disaster Database is based on information that is sourced from outside parties and may not be accurate and should therefore be interpreted with caution. (Public Safety Canada)
+
+# Global
 SDG_GOAL__GLOBAL: '<p>Goal 1: End poverty in all its forms everywhere</p>'
-SDG_TARGET__GLOBAL: '<p>Target 1.5: By 2030, build the resilience of the poor and those in
-  vulnerable situations and reduce their exposure and vulnerability to climate-related
-  extreme events and other economic, social and environmental shocks and disasters</p>'
-SDG_INDICATOR__GLOBAL: '<p>Indicator 1.5.1: Number of deaths, missing persons and directly
-  affected persons attributed to disasters per 100,000 population</p>'
+SDG_TARGET__GLOBAL: >-
+  Target 1.5: By 2030, build the resilience of the poor and those in vulnerable situations and reduce their exposure and vulnerability to climate-related extreme events and other economic, social and environmental shocks and disasters
+SDG_INDICATOR__GLOBAL: >-
+  Indicator 1.5.1: Number of deaths, missing persons and directly affected persons attributed to disasters per 100,000 population
+
 un_designated_tier: Tier I
-un_custodian_agency: United Nations Office for Disaster Reduction (UNISDR)
+un_custodian_agency: United Nations Office for Disaster Risk Reduction (UNDRR)
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-01-05-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata
 
+# Source(s)
 source_active_1: 'true'
-source_url_text_1: |
-    Public Safety Canada. The Canadian Disaster Database
+source_url_text_1: Public Safety Canada. The Canadian Disaster Database
 source_url_1: https://www.publicsafety.gc.ca/cnt/rsrcs/cndn-dsstr-dtbs/index-en.aspx
 source_organisation_1: Public Safety Canada
 source_periodicity_1: Occasional
-source_geographical_coverage_1: Canada, Geographical region of Canada, Province or
-  territory
+source_geographical_coverage_1: Canada, Geographical region of Canada, Province or territory
 
 source_active_2: 'true'
 source_url_text_2: Table 17-10-0005-01  Population estimates on July 1st, by age and sex

--- a/meta/1-5-2.yml
+++ b/meta/1-5-2.yml
@@ -22,9 +22,9 @@ STAT_CONC_DEF: >-
   <li>significant damage/interruption of normal processes such that the community affected cannot recover on its own. (Public Safety Canada)</li>
   </ul>
 DATA_COMP: >-
-  Direct economic loss attributed to disasters is calculated as a percentage of the gross domestic product (GDP) in current prices: 
+  For each year, direct economic loss attributed to disasters is calculated as a percentage of the gross domestic product (GDP) in current prices: 
   <br>
-  Direct economic loss attributed to disasters / GDP in current prices × 100
+  Estimated total costs / GDP in current prices × 100
 REC_USE_LIM: >-
   This is a proxy indicator that measures direct economic loss attributed to disasters in relation to Canada's gross domestic product (GDP) whereas the UN Global indicator states: "Direct economic loss attributed to disasters in relation to global gross domestic product (GDP)".
   <br><br>

--- a/meta/1-5-2.yml
+++ b/meta/1-5-2.yml
@@ -26,7 +26,7 @@ DATA_COMP: >-
   <br>
   Estimated total costs / GDP in current prices × 100
 REC_USE_LIM: >-
-  This is a proxy indicator that measures direct economic loss attributed to disasters in relation to Canada's gross domestic product (GDP) whereas the UN Global indicator states: "Direct economic loss attributed to disasters in relation to global gross domestic product (GDP)".
+  This is a proxy indicator that measures direct economic loss attributed to disasters in relation to Canada's gross domestic product (GDP), whereas the UN Global indicator states: "Direct economic loss attributed to disasters in relation to global gross domestic product (GDP)".
   <br><br>
   It is important to note that the Canadian Disaster Database may not be suitable for comparative analysis because of differences in jurisdictional responsibilities, the type of data that is available, and how it is collected and used over time.
   <br><br>

--- a/meta/11-5-1.yml
+++ b/meta/11-5-1.yml
@@ -1,39 +1,52 @@
-# NATIONAL
+# National
 SDG_GOAL: '<p>Goal 11: Make cities and human settlements inclusive, safe, resilient and sustainable</p>'
-SDG_TARGET: |
+SDG_TARGET: >-
     Target 11.5: By 2030, significantly reduce the number of deaths and the number of people affected and substantially decrease the direct economic losses relative to global gross domestic product caused by disasters, including water-related disasters, with a focus on protecting the poor and people in vulnerable situations
-SDG_INDICATOR: |
+SDG_INDICATOR: >-
     Indicator 11.5.1: Number of deaths, missing persons and directly affected persons attributed to disasters per 100,000 population
-STAT_CONC_DEF: '<strong>Definition:</strong> <br>This indicator measures the number of people who died, went missing or
-  were directly affected by disasters per 100,000 population.<br><br><strong>Concepts:</strong><br> Death: The number of people who died during the disaster, or directly after, as a direct result of the 
-  hazardous event. <br><br> Missing: The number of people whose whereabouts is unknown since the hazardous event. It includes people who are presumed dead, for whom there is no physical evidence such as a body, and for which an official/legal report has been filed with competent authorities.<br><br> Directly affected: The number of people who have suffered injury, illness or other health effects; who were evacuated, displaced, relocated or have suffered direct damage to their livelihoods, economic, physical, social, cultural and environmental assets. Indirectly affected are people who have suffered consequences, other than or in addition to direct effects, over time, due to disruption or changes in economy, critical infrastructure, basic services, commerce or work, or social, health and psychological consequences. <br><br>
-  The Canadian Disaster Database (CDD) tracks significant disaster events that conform to the Emergency Management Framework for Canada definition of a disaster and meet one or more of the following criteria:
-  <br> - 10 or more people killed;
-  <br> - 100 or more people affected/injured/infected/evacuated or homeless;
-  <br> - an appeal for national/international assistance;
-  <br> - historical significance;
-  <br> - significant damage/interruption of normal processes such that the community affected cannot recover on its own. (Public Safety Canada)'
-DATA_COMP: '((Number of deaths, missing persons and directly affected persons attributed to disasters) / Population) x 100,000 = Rate per 100,000 population'
-REC_USE_LIM: 'It is important to note that the Canadian Disaster Database may not be suitable for comparative analysis because of differences in jurisdictional responsibilities, the type of data that is available, and how it is collected and used over time.
-  <br><br> The information contained in the Canadian Disaster Database is based on information that is sourced from outside parties and may not be accurate and should therefore be interpreted with caution. (Public Safety Canada)'
+STAT_CONC_DEF: >-
+  <p><strong>Definition:</strong><br>
+  This indicator measures the number of people who died, went missing or were directly affected by disasters per 100,000 population.</p>
+  <p><strong>Concepts:</strong><br>
+  Death: The number of people who died during the disaster, or directly after, as a direct result of the hazardous event.
+  <br><br>
+  Missing: The number of people whose whereabouts is unknown since the hazardous event. It includes people who are presumed dead, for whom there is no physical evidence such as a body, and for which an official/legal report has been filed with competent authorities.
+  <br><br>
+  Directly affected: The number of people who have suffered injury, illness or other health effects; who were evacuated, displaced, relocated or have suffered direct damage to their livelihoods, economic, physical, social, cultural and environmental assets. Indirectly affected are people who have suffered consequences, other than or in addition to direct effects, over time, due to disruption or changes in economy, critical infrastructure, basic services, commerce or work, or social, health and psychological consequences.</p>
+  <p>The Canadian Disaster Database (CDD) tracks significant disaster events that conform to the Emergency Management Framework for Canada definition of a disaster and meet one or more of the following criteria:</p>
+  <ul>
+  <li>10 or more people killed;</li>
+  <li>100 or more people affected/injured/infected/evacuated or homeless;</li>
+  <li>an appeal for national/international assistance;</li>
+  <li>historical significance;</li>
+  <li>significant damage/interruption of normal processes such that the community affected cannot recover on its own. (Public Safety Canada)</li>
+  </ul>
+DATA_COMP: >-
+  Number of deaths, missing persons and directly affected persons attributed to disasters) / Population × 100,000 = Rate per 100,000 population
+REC_USE_LIM: >-
+  It is important to note that the Canadian Disaster Database may not be suitable for comparative analysis because of differences in jurisdictional responsibilities, the type of data that is available, and how it is collected and used over time.
+  <br><br>
+  The information contained in the Canadian Disaster Database is based on information that is sourced from outside parties and may not be accurate and should therefore be interpreted with caution. (Public Safety Canada)
+
+# Global
 SDG_GOAL__GLOBAL: '<p>Goal 11: Make cities and human settlements inclusive, safe, resilient and sustainable</p>'
-SDG_TARGET__GLOBAL: |
-    Target 11.5: By 2030, significantly reduce the number of deaths and the number of people affected and substantially decrease the direct economic losses relative to global gross domestic product caused by disasters, including water-related disasters, with a focus on protecting the poor and people in vulnerable situations
-SDG_INDICATOR__GLOBAL: |
-    Indicator 11.5.1: Number of deaths, missing persons and directly affected persons attributed to disasters per 100,000 population
+SDG_TARGET__GLOBAL: >-
+  Target 11.5: By 2030, significantly reduce the number of deaths and the number of people affected and substantially decrease the direct economic losses relative to global gross domestic product caused by disasters, including water-related disasters, with a focus on protecting the poor and people in vulnerable situations
+SDG_INDICATOR__GLOBAL: >-
+  Indicator 11.5.1: Number of deaths, missing persons and directly affected persons attributed to disasters per 100,000 population
+
 un_designated_tier: Tier I
-un_custodian_agency: United Nations Office for Disaster Reduction (UNISDR)
+un_custodian_agency: United Nations Office for Disaster Risk Reduction (UNDRR)
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-11-05-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata
 
+# Source(s)
 source_active_1: 'true'
-source_url_text_1: |
-    Public Safety Canada. The Canadian Disaster Database.
+source_url_text_1: Public Safety Canada. The Canadian Disaster Database
 source_url_1: https://www.publicsafety.gc.ca/cnt/rsrcs/cndn-dsstr-dtbs/index-en.aspx
 source_organisation_1: Public Safety Canada
 source_periodicity_1: Occasional
-source_geographical_coverage_1: Canada, Geographical region of Canada, Province or
-  territory
+source_geographical_coverage_1: Canada, Geographical region of Canada, Province or territory
 
 source_active_2: 'true'
 source_url_text_2: Table 17-10-0005-01  Population estimates on July 1st, by age and sex

--- a/meta/11-5-2.yml
+++ b/meta/11-5-2.yml
@@ -22,9 +22,9 @@ STAT_CONC_DEF: >-
   <li>significant damage/interruption of normal processes such that the community affected cannot recover on its own. (Public Safety Canada)</li>
   </ul>
 DATA_COMP: >-
-  Direct economic loss attributed to disasters is calculated as a percentage of the gross domestic product (GDP) in current prices: 
+  For each year, direct economic loss attributed to disasters is calculated as a percentage of the gross domestic product (GDP) in current prices: 
   <br>
-  Direct economic loss attributed to disasters / GDP in current prices × 100
+  Estimated total costs / GDP in current prices × 100
 REC_USE_LIM: >-
   This is a proxy indicator that measures direct economic loss attributed to disasters in relation to Canada's gross domestic product (GDP) whereas the UN Global indicator states: "Direct economic loss attributed to disasters in relation to global gross domestic product (GDP)".
   <br><br>

--- a/meta/11-5-2.yml
+++ b/meta/11-5-2.yml
@@ -26,7 +26,7 @@ DATA_COMP: >-
   <br>
   Estimated total costs / GDP in current prices × 100
 REC_USE_LIM: >-
-  This is a proxy indicator that measures direct economic loss attributed to disasters in relation to Canada's gross domestic product (GDP) whereas the UN Global indicator states: "Direct economic loss attributed to disasters in relation to global gross domestic product (GDP)".
+  This is a proxy indicator that measures direct economic loss attributed to disasters in relation to Canada's gross domestic product (GDP), whereas the UN Global indicator states: "Direct economic loss attributed to disasters in relation to global gross domestic product (GDP)".
   <br><br>
   It is important to note that the Canadian Disaster Database may not be suitable for comparative analysis because of differences in jurisdictional responsibilities, the type of data that is available, and how it is collected and used over time.
   <br><br>

--- a/meta/13-1-1.yml
+++ b/meta/13-1-1.yml
@@ -1,39 +1,51 @@
 SDG_GOAL: '<p>Goal 13: Take urgent action to combat climate change and its impacts</p>'
-SDG_TARGET: '<p>Target 13.1: Strengthen resilience and adaptive capacity to 
-  climate-related hazards and natural disasters in all countries</p>'
-SDG_INDICATOR: '<p>Indicator 13.1.1: Number of deaths, missing persons and directly affected persons
-  attributed to disasters per 100,000 population</p>'
-STAT_CONC_DEF: '<strong>Definition:</strong> <br>This indicator measures the number of people who died, went missing or
-  were directly affected by disasters per 100,000 population.<br><br><strong>Concepts:</strong><br> Death: The number of people who died during the disaster, or directly after, as a direct result of the 
-  hazardous event. <br><br> Missing: The number of people whose whereabouts is unknown since the hazardous event. It includes people who are presumed dead, for whom there is no physical evidence such as a body, and for which an official/legal report has been filed with competent authorities.<br><br> Directly affected: The number of people who have suffered injury, illness or other health effects; who were evacuated, displaced, relocated or have suffered direct damage to their livelihoods, economic, physical, social, cultural and environmental assets. Indirectly affected are people who have suffered consequences, other than or in addition to direct effects, over time, due to disruption or changes in economy, critical infrastructure, basic services, commerce or work, or social, health and psychological consequences. 
+SDG_TARGET: >-
+  Target 13.1: Strengthen resilience and adaptive capacity to climate-related hazards and natural disasters in all countries
+SDG_INDICATOR: >-
+  Indicator 13.1.1: Number of deaths, missing persons and directly affected persons attributed to disasters per 100,000 population
+STAT_CONC_DEF: >-
+  <p><strong>Definition:</strong><br>
+  This indicator measures the number of people who died, went missing or were directly affected by disasters per 100,000 population.</p>
+  <p><strong>Concepts:</strong><br>
+  Death: The number of people who died during the disaster, or directly after, as a direct result of the hazardous event.
   <br><br>
-  The Canadian Disaster Database (CDD) tracks significant disaster events that conform to the Emergency Management Framework for Canada definition of a disaster and meet one or more of the following criteria:
-  <br> - 10 or more people killed;
-  <br> - 100 or more people affected/injured/infected/evacuated or homeless;
-  <br> - an appeal for national/international assistance;
-  <br> - historical significance;
-  <br> - significant damage/interruption of normal processes such that the community affected cannot recover on its own. (Public Safety Canada)'
-DATA_COMP: '((Number of deaths, missing persons and directly affected persons attributed to disasters) / Population) x 100,000 = Rate per 100,000 population'
-REC_USE_LIM: 'It is important to note that the Canadian Disaster Database may not be suitable for comparative analysis because of differences in jurisdictional responsibilities, the type of data that is available, and how it is collected and used over time.
-  <br><br> The information contained in the Canadian Disaster Database is based on information that is sourced from outside parties and may not be accurate and should therefore be interpreted with caution. (Public Safety Canada)'
+  Missing: The number of people whose whereabouts is unknown since the hazardous event. It includes people who are presumed dead, for whom there is no physical evidence such as a body, and for which an official/legal report has been filed with competent authorities.
+  <br><br>
+  Directly affected: The number of people who have suffered injury, illness or other health effects; who were evacuated, displaced, relocated or have suffered direct damage to their livelihoods, economic, physical, social, cultural and environmental assets. Indirectly affected are people who have suffered consequences, other than or in addition to direct effects, over time, due to disruption or changes in economy, critical infrastructure, basic services, commerce or work, or social, health and psychological consequences.</p>
+  <p>The Canadian Disaster Database (CDD) tracks significant disaster events that conform to the Emergency Management Framework for Canada definition of a disaster and meet one or more of the following criteria:</p>
+  <ul>
+  <li>10 or more people killed;</li>
+  <li>100 or more people affected/injured/infected/evacuated or homeless;</li>
+  <li>an appeal for national/international assistance;</li>
+  <li>historical significance;</li>
+  <li>significant damage/interruption of normal processes such that the community affected cannot recover on its own. (Public Safety Canada)</li>
+  </ul>
+DATA_COMP: >-
+  Number of deaths, missing persons and directly affected persons attributed to disasters) / Population × 100,000 = Rate per 100,000 population
+REC_USE_LIM: >-
+  It is important to note that the Canadian Disaster Database may not be suitable for comparative analysis because of differences in jurisdictional responsibilities, the type of data that is available, and how it is collected and used over time.
+  <br><br>
+  The information contained in the Canadian Disaster Database is based on information that is sourced from outside parties and may not be accurate and should therefore be interpreted with caution. (Public Safety Canada)
+
+# Global
 SDG_GOAL__GLOBAL: '<p>Goal 13: Take urgent action to combat climate change and its impacts</p>'
-SDG_TARGET__GLOBAL: '<p>Target 13.1: Strengthen resilience and adaptive capacity to 
-  climate-related hazards and natural disasters in all countries</p>'
-SDG_INDICATOR__GLOBAL: '<p>Indicator 13.1.1: Number of deaths, missing persons and directly affected persons
-  attributed to disasters per 100,000 population</p>'
+SDG_TARGET__GLOBAL: >-
+  Target 13.1: Strengthen resilience and adaptive capacity to climate-related hazards and natural disasters in all countries
+SDG_INDICATOR__GLOBAL: >-
+  Indicator 13.1.1: Number of deaths, missing persons and directly affected persons attributed to disasters per 100,000 population
+
 un_designated_tier: Tier I
-un_custodian_agency: United Nations Office for Disaster Reduction (UNISDR)
+un_custodian_agency: United Nations Office for Disaster Risk Reduction (UNDRR)
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-13-01-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata
 
+# Source(s)
 source_active_1: 'true'
-source_url_text_1: |
-    Public Safety Canada. The Canadian Disaster Database
+source_url_text_1: Public Safety Canada. The Canadian Disaster Database
 source_url_1: https://www.publicsafety.gc.ca/cnt/rsrcs/cndn-dsstr-dtbs/index-en.aspx
 source_organisation_1: Public Safety Canada
 source_periodicity_1: Occasional
-source_geographical_coverage_1: Canada, Geographical region of Canada, Province or
-  territory
+source_geographical_coverage_1: Canada, Geographical region of Canada, Province or territory
 
 source_active_2: 'true'
 source_url_text_2: Table 17-10-0005-01  Population estimates on July 1st, by age and sex

--- a/meta/fr/1-5-1.yml
+++ b/meta/fr/1-5-1.yml
@@ -1,27 +1,48 @@
+# National
 SDG_GOAL: '<p>Objectif 1 : Éliminer la pauvreté sous toutes ses formes et partout dans le monde</p>'
-SDG_TARGET: "<p>Cible 1.5 : D’ici à 2030, renforcer la résilience des pauvres et des personnes en situation vulnérable et réduire leur exposition aux phénomènes climatiques extrêmes et à d’autres chocs et catastrophes d’ordre économique, social ou environnemental et leur vulnérabilité</p>"
-SDG_INDICATOR: '<p>Indicateur 1.5.1 : Nombre de personnes décédées, disparues ou directement touchées lors de catastrophes, par 100 000 personnes'
-STAT_CONC_DEF: |
-    <strong>Définition:</strong> <br>Cet indicateur mesure le nombre de personnes décédées, disparues ou directement touchées lors de catastrophes, par 100 000 personnes.
-    <br><br><strong>Concepts:</strong><br> Décédées : nombre de personnes décédées pendant la catastrophe, ou immédiatement après, en conséquence directe de l'événement dangereux. 
-    <br><br> Disparues : nombre de personnes dont on ne sait pas où elles se trouvent depuis l'événement dangereux. Cela inclut les personnes présumées mortes, pour lesquelles il n’existe aucune preuve physique telle qu’un corps, et pour lesquelles un rapport officiel/légal a été déposé auprès des autorités compétentes.
-    <br><br> Directement touchées : le nombre de personnes ayant subi une blessure, une maladie ou d'autres problèmes de santé ; qui ont été évacuées, déplacées, relocalisées ou qui ont subi des dommages directs à leurs moyens de subsistance et à leurs biens économiques, physiques, sociaux, culturels et environnementaux. Sont indirectement touchées les personnes qui ont subi des conséquences, autres ou en plus des effets directs, au fil du temps, en raison de perturbations ou de changements dans l'économie, les infrastructures critiques, les services de base, le commerce ou le travail, ou de conséquences sociales, sanitaires et psychologiques.<br>
-    La Base de données canadienne sur les catastrophes (BDC) permet de trouver les « catastrophes importantes » qui correspondent à la définition utilisée dans le document Un cadre de sécurité civile pour le Canada et satisfont à l'un ou à plusieurs des critères suivants :
-    <br> - dix personnes ou plus ont été tuées;
-    <br> - cent personnes ou plus ont été touchées, blessées, infectées, évacuées ou se sont trouvées sans logement;
-    <br> - une demande d'aide a été effectuée à l'échelle nationale ou internationale;
-    <br> - la catastrophe revêt une importance historique;
-    <br> - les dommages ou l'interruption des processus normaux étaient tels que la collectivité touchée n'a pu se rétablir seule. (Sécurité publique Canada)
-DATA_COMP: '((Nombre de personnes décédées, disparues ou directement touchées lors de catastrophes) / Population) x 100,000 = Taux par 100,000 habitants'
-REC_USE_LIM: 'Il est important de noter que la BDC pourrait ne pas convenir aux analyses comparatives en raison des écarts de responsabilités entre les différentes administrations, du type de données disponibles et des façons de les recueillir et les utiliser au fil du temps. 
-  <br><br> Les renseignements présentés dans la Banque de données canadienne sur les catastrophes sont fondés sur des données fournies par des tiers et pourraient ne pas être exacts. (Sécurité publique Canada)'
-SDG_GOAL__GLOBAL: '<p>Objectif 1 : Éliminer la pauvreté sous toutes ses formes et partout dans le monde</p>'
-SDG_TARGET__GLOBAL: "<p>Cible 1.5 : D’ici à 2030, renforcer la résilience des pauvres et des personnes en situation vulnérable et réduire leur exposition aux phénomènes climatiques extrêmes et à d’autres chocs et catastrophes d’ordre économique, social ou environnemental et leur vulnérabilité</p>"
-SDG_INDICATOR__GLOBAL: '<p>Indicateur 1.5.1 : Nombre de personnes décédées, disparues ou directement touchées lors de catastrophes, par 100 000 personnes'
+SDG_TARGET: >-
+  Cible 1.5 : D’ici à 2030, renforcer la résilience des pauvres et des personnes en situation vulnérable et réduire leur exposition aux phénomènes climatiques extrêmes et à d’autres chocs et catastrophes d’ordre économique, social ou environnemental et leur vulnérabilité
+SDG_INDICATOR: >-
+  Indicateur 1.5.1 : Nombre de personnes décédées, disparues ou directement touchées lors de catastrophes, par 100 000 personnes
+STAT_CONC_DEF: >-
+  <p><strong>Définition :</strong><br>
+  Cet indicateur mesure le nombre de personnes décédées, disparues ou directement touchées lors de catastrophes, par 100 000 personnes.</p>
+  <p><strong>Concepts :</strong><br>
+  Décédées : nombre de personnes décédées pendant la catastrophe, ou immédiatement après, en conséquence directe de l'événement dangereux. 
+  <br><br>
+  Disparues : nombre de personnes dont on ne sait pas où elles se trouvent depuis l'événement dangereux. Cela inclut les personnes présumées mortes, pour lesquelles il n’existe aucune preuve physique telle qu’un corps, et pour lesquelles un rapport officiel/légal a été déposé auprès des autorités compétentes.
+  <br><br>
+  Directement touchées : le nombre de personnes ayant subi une blessure, une maladie ou d'autres problèmes de santé ; qui ont été évacuées, déplacées, relocalisées ou qui ont subi des dommages directs à leurs moyens de subsistance et à leurs biens économiques, physiques, sociaux, culturels et environnementaux. Sont indirectement touchées les personnes qui ont subi des conséquences, autres ou en plus des effets directs, au fil du temps, en raison de perturbations ou de changements dans l'économie, les infrastructures critiques, les services de base, le commerce ou le travail, ou de conséquences sociales, sanitaires et psychologiques.</p>
+  <p>La Base de données canadienne sur les catastrophes (BDC) permet de trouver les « catastrophes importantes » qui correspondent à la définition utilisée dans le document Un cadre de sécurité civile pour le Canada et satisfont à l'un ou à plusieurs des critères suivants :</p>
+  <ul>
+  <li>dix personnes ou plus ont été tuées ;</li>
+  <li>cent personnes ou plus ont été touchées, blessées, infectées, évacuées ou se sont trouvées sans logement ;</li>
+  <li>une demande d'aide a été effectuée à l'échelle nationale ou internationale ;</li>
+  <li>la catastrophe revêt une importance historique ;</li>
+  <li>les dommages ou l'interruption des processus normaux étaient tels que la collectivité touchée n'a pu se rétablir seule. (Sécurité publique Canada)</li>
+  </ul>
+DATA_COMP: >-
+  Nombre de personnes décédées, disparues ou directement touchées lors de catastrophes) / Population) x 100,000 = Taux par 100,000 habitants
+REC_USE_LIM: >-
+  Il est important de noter que la BDC pourrait ne pas convenir aux analyses comparatives en raison des écarts de responsabilités entre les différentes administrations, du type de données disponibles et des façons de les recueillir et les utiliser au fil du temps. 
+  <br><br>
+  Les renseignements présentés dans la Banque de données canadienne sur les catastrophes sont fondés sur des données fournies par des tiers et pourraient ne pas être exacts. (Sécurité publique Canada)
 
+# Global
+SDG_GOAL__GLOBAL: '<p>Objectif 1 : Éliminer la pauvreté sous toutes ses formes et partout dans le monde</p>'
+SDG_TARGET__GLOBAL: >-
+  Cible 1.5 : D’ici à 2030, renforcer la résilience des pauvres et des personnes en situation vulnérable et réduire leur exposition aux phénomènes climatiques extrêmes et à d’autres chocs et catastrophes d’ordre économique, social ou environnemental et leur vulnérabilité
+SDG_INDICATOR__GLOBAL: >-
+  Indicateur 1.5.1 : Nombre de personnes décédées, disparues ou directement touchées lors de catastrophes, par 100 000 personnes
+
+un_designated_tier: Niveau I
+un_custodian_agency: Bureau des Nations Unies pour la réduction des risques des catastrophes (UNDRR)
+goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-01-05-01.pdf
+goal_meta_link_text: Métadonnées des objectifs de développement durable des Nations Unies
+
+# Source(s)
 source_active_1: 'true'
-source_url_text_1: |
-    Sécurité publique Canada. Base de données canadienne sur les catastrophes
+source_url_text_1: Sécurité publique Canada. Base de données canadienne sur les catastrophes
 source_url_1: https://www.securitepublique.gc.ca/cnt/rsrcs/cndn-dsstr-dtbs/index-fr.aspx
 source_organisation_1: Sécurité publique Canada
 source_periodicity_1: Occasionnelle
@@ -30,13 +51,7 @@ source_geographical_coverage_1: Canada, Région géographique du Canada, Provinc
 source_active_2: 'true'
 source_url_text_2: 'Tableau 17-10-0005-01  Estimations de la population au 1er juillet, par âge et sexe'
 source_url_2: https://doi.org/10.25318/1710000501-fra
-source_organisation_2: Statistics Canada
-source_periodicity_2: Annual
-source_geographical_coverage_2: Canada, Province or territory
-
-un_designated_tier: Niveau I
-un_custodian_agency: Département des Affaires Économiques et Sociales
-goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-01-05-01.pdf
-goal_meta_link_text: Métadonnées des objectifs de développement durable des Nations Unies
-
+source_organisation_2: Statistique Canada
+source_periodicity_2: Annuelle
+source_geographical_coverage_2: Canada, Province ou territoire
  

--- a/meta/fr/1-5-2.yml
+++ b/meta/fr/1-5-2.yml
@@ -5,7 +5,7 @@ SDG_INDICATOR: >-
   Indicateur 1.5.2 : Pertes économiques directement attribuables à des catastrophes par rapport au produit intérieur brut (PIB)
 STAT_CONC_DEF: >-
   <p><strong>Définition :</strong><br>
-  Cet indicateur mesure les pertes économiques directement attribuables à des catastrophes par rapport au produit intérieur brut mondial (PIB).
+  Cet indicateur mesure les pertes économiques directement attribuables à des catastrophes par rapport au produit intérieur brut mondial (PIB).</p>
   <p><strong>Concepts :</strong><br>
   Perte économique : impact économique total composé d’une perte économique directe et d’une perte économique indirecte.
   <br><br>
@@ -15,7 +15,7 @@ STAT_CONC_DEF: >-
   <p>La Base de données canadienne sur les catastrophes (BDC) permet de trouver les « catastrophes importantes » qui correspondent à la définition utilisée dans le document Un cadre de sécurité civile pour le Canada et satisfont à l'un ou à plusieurs des critères suivants :</p>
   <ul>
   <li>dix personnes ou plus ont été tuées ;</li>
-  <li>cent personnes ou plus ont été touchées, blessées, infectées, évacuées ou se sont trouvées sans logement;</li>
+  <li>cent personnes ou plus ont été touchées, blessées, infectées, évacuées ou se sont trouvées sans logement ;</li>
   <li>une demande d'aide a été effectuée à l'échelle nationale ou internationale ;</li>
   <li>la catastrophe revêt une importance historique ;</li>
   <li>les dommages ou l'interruption des processus normaux étaient tels que la collectivité touchée n'a pu se rétablir seule. (Sécurité publique Canada)</li>
@@ -59,5 +59,4 @@ source_organisation_2: Statistique Canada
 source_periodicity_2: Annuelle
 source_geographical_coverage_2: Canada
 source_url_2: https://doi.org/10.25318/3610022201-fra
-
  

--- a/meta/fr/1-5-2.yml
+++ b/meta/fr/1-5-2.yml
@@ -20,9 +20,9 @@ STAT_CONC_DEF: >-
   <li>les dommages ou l'interruption des processus normaux étaient tels que la collectivité touchée n'a pu se rétablir seule. (Sécurité publique Canada)</li>
   </ul>
 DATA_COMP: >-
-  Les pertes économiques directement attribuables à des catastrophes sont calculées comme un pourcentage du produit intérieur brut (PIB) en prix courants :
+  Pour chaque année, les pertes économiques directement attribuables à des catastrophes sont calculées comme un pourcentage du produit intérieur brut (PIB) en prix courants :
   <br>
-  Pertes économiques directement attribuables à des catastrophes / PIB en prix courants × 100
+  Coût total estimé / PIB en prix courants × 100
 REC_USE_LIM: >-
   Cet indicateur est un proxy mesurant les pertes économiques directement attribuables à des catastrophes par rapport au produit intérieur brut (PIB) du Canada, tandis que l'indicateur global de l'ONU indique : « Pertes économiques directement attribuables à des catastrophes par rapport au produit intérieur brut mondial (PIB) »
   <br><br>

--- a/meta/fr/1-5-2.yml
+++ b/meta/fr/1-5-2.yml
@@ -4,9 +4,10 @@ SDG_TARGET: "<p>Cible 1.5 : D’ici à 2030, renforcer la résilience des pauv
 SDG_INDICATOR: >-
   Indicateur 1.5.2 : Pertes économiques directement attribuables à des catastrophes par rapport au produit intérieur brut (PIB)
 STAT_CONC_DEF: >-
-  <p>strong>Définition :</strong><br>
+  <p><strong>Définition :</strong><br>
   Cet indicateur mesure les pertes économiques directement attribuables à des catastrophes par rapport au produit intérieur brut mondial (PIB).
-  <p><strong>Concepts :</strong><br>Perte économique : impact économique total composé d’une perte économique directe et d’une perte économique indirecte.
+  <p><strong>Concepts :</strong><br>
+  Perte économique : impact économique total composé d’une perte économique directe et d’une perte économique indirecte.
   <br><br>
   Perte économique directe : la valeur monétaire de la destruction totale ou partielle des actifs physiques existant dans la zone touchée. Les pertes économiques directes sont presque équivalentes aux dommages physiques.
   <br><br>
@@ -28,7 +29,7 @@ REC_USE_LIM: >-
   <br><br>
   Il est important de noter que la BDC pourrait ne pas convenir aux analyses comparatives en raison des écarts de responsabilités entre les différentes administrations, du type de données disponibles et des façons de les recueillir et les utiliser au fil du temps. 
   <br><br>
-  Les renseignements présentés dans la BDC sont fondés sur des données fournies par des tiers et pourraient ne pas être exacts. (Sécurité publique Canada)'
+  Les renseignements présentés dans la BDC sont fondés sur des données fournies par des tiers et pourraient ne pas être exacts. (Sécurité publique Canada)
 
 proxy: proxy
 

--- a/meta/fr/11-5-1.yml
+++ b/meta/fr/11-5-1.yml
@@ -1,34 +1,52 @@
-# NATIONAL
-SDG_GOAL: '<p>Objectif 11 : Faire en sorte que les villes et les établissements humains
-  soient ouverts à tous, sûrs, résilients et durables</p>'
-SDG_TARGET: |
-     Cible 11.5 : D’ici à 2030, renforcer la résilience des pauvres et des personnes en situation vulnérable et réduire leur exposition aux phénomènes climatiques extrêmes et à d’autres chocs et catastrophes d’ordre économique, social ou environnemental et leur vulnérabilité
-SDG_INDICATOR: |
-    Indicateur 11.5.1 : Nombre de personnes décédées, disparues ou directement touchées lors de catastrophes, par 100 000 personnes
-STAT_CONC_DEF: '    '
-DATA_COMP: '   '
-REC_USE_LIM: '   '
- 
+# National
+SDG_GOAL: '<p>Objectif 11 : Faire en sorte que les villes et les établissements humains soient ouverts à tous, sûrs, résilients et durables</p>'
+SDG_TARGET: >-
+  Cible 11.5 : D’ici à 2030, renforcer la résilience des pauvres et des personnes en situation vulnérable et réduire leur exposition aux phénomènes climatiques extrêmes et à d’autres chocs et catastrophes d’ordre économique, social ou environnemental et leur vulnérabilité
+SDG_INDICATOR: >-
+  Indicateur 11.5.1 : Nombre de personnes décédées, disparues ou directement touchées lors de catastrophes, par 100 000 personnes
+STAT_CONC_DEF: >-
+  <p><strong>Définition :</strong><br>
+  Cet indicateur mesure le nombre de personnes décédées, disparues ou directement touchées lors de catastrophes, par 100 000 personnes.</p>
+  <p><strong>Concepts :</strong><br>
+  Décédées : nombre de personnes décédées pendant la catastrophe, ou immédiatement après, en conséquence directe de l'événement dangereux. 
+  <br><br>
+  Disparues : nombre de personnes dont on ne sait pas où elles se trouvent depuis l'événement dangereux. Cela inclut les personnes présumées mortes, pour lesquelles il n’existe aucune preuve physique telle qu’un corps, et pour lesquelles un rapport officiel/légal a été déposé auprès des autorités compétentes.
+  <br><br>
+  Directement touchées : le nombre de personnes ayant subi une blessure, une maladie ou d'autres problèmes de santé ; qui ont été évacuées, déplacées, relocalisées ou qui ont subi des dommages directs à leurs moyens de subsistance et à leurs biens économiques, physiques, sociaux, culturels et environnementaux. Sont indirectement touchées les personnes qui ont subi des conséquences, autres ou en plus des effets directs, au fil du temps, en raison de perturbations ou de changements dans l'économie, les infrastructures critiques, les services de base, le commerce ou le travail, ou de conséquences sociales, sanitaires et psychologiques.</p>
+  <p>La Base de données canadienne sur les catastrophes (BDC) permet de trouver les « catastrophes importantes » qui correspondent à la définition utilisée dans le document Un cadre de sécurité civile pour le Canada et satisfont à l'un ou à plusieurs des critères suivants :</p>
+  <ul>
+  <li>dix personnes ou plus ont été tuées ;</li>
+  <li>cent personnes ou plus ont été touchées, blessées, infectées, évacuées ou se sont trouvées sans logement ;</li>
+  <li>une demande d'aide a été effectuée à l'échelle nationale ou internationale ;</li>
+  <li>la catastrophe revêt une importance historique ;</li>
+  <li>les dommages ou l'interruption des processus normaux étaient tels que la collectivité touchée n'a pu se rétablir seule. (Sécurité publique Canada)</li>
+  </ul>
+DATA_COMP: >-
+  Nombre de personnes décédées, disparues ou directement touchées lors de catastrophes) / Population) x 100,000 = Taux par 100,000 habitants
+REC_USE_LIM: >-
+  Il est important de noter que la BDC pourrait ne pas convenir aux analyses comparatives en raison des écarts de responsabilités entre les différentes administrations, du type de données disponibles et des façons de les recueillir et les utiliser au fil du temps. 
+  <br><br>
+  Les renseignements présentés dans la Banque de données canadienne sur les catastrophes sont fondés sur des données fournies par des tiers et pourraient ne pas être exacts. (Sécurité publique Canada)
 
-# GLOBAL
-SDG_GOAL__GLOBAL: '<p>Objectif 11 : Faire en sorte que les villes et les établissements
-  humains soient ouverts à tous, sûrs, résilients et durables</p>'
-SDG_TARGET__GLOBAL: |
+# Global
+SDG_GOAL__GLOBAL: '<p>Objectif 11 : Faire en sorte que les villes et les établissements humains soient ouverts à tous, sûrs, résilients et durables</p>'
+SDG_TARGET__GLOBAL: >-
     Cible 11.5 : D’ici à 2030, renforcer la résilience des pauvres et des personnes en situation vulnérable et réduire leur exposition aux phénomènes climatiques extrêmes et à d’autres chocs et catastrophes d’ordre économique, social ou environnemental et leur vulnérabilité
-SDG_INDICATOR__GLOBAL: |
+SDG_INDICATOR__GLOBAL: >-
     Indicateur 11.5.1 : Nombre de personnes décédées, disparues ou directement touchées lors de catastrophes, par 100 000 personnes
   
 un_designated_tier: Niveau I
-un_custodian_agency: Le Bureau des Nations Unies pour la réduction des risques de catastrophe (UNDRR)
+un_custodian_agency: Bureau des Nations Unies pour la réduction des risques des catastrophes (UNDRR)
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-11-05-01.pdf
 goal_meta_link_text: Métadonnées des objectifs de développement durable des Nations Unies
 
-# SOURCE(S)
+# Source(s)
 source_active_1: 'true'
-source_url_text_1: |
-    Sécurité publique Canada. Base de données canadienne sur les catastrophes
+source_url_text_1: Sécurité publique Canada. Base de données canadienne sur les catastrophes
 source_url_1: https://www.securitepublique.gc.ca/cnt/rsrcs/cndn-dsstr-dtbs/index-fr.aspx
 source_organisation_1: Sécurité publique Canada
+source_periodicity_1: Occasionnelle
+source_geographical_coverage_1: Canada, Région géographique du Canada, Province ou territoire
 
 source_active_2: 'true'
 source_url_text_2: 'Tableau 17-10-0005-01  Estimations de la population au 1er juillet, par âge et sexe'

--- a/meta/fr/11-5-2.yml
+++ b/meta/fr/11-5-2.yml
@@ -22,9 +22,9 @@ STAT_CONC_DEF: >-
   <li>les dommages ou l'interruption des processus normaux étaient tels que la collectivité touchée n'a pu se rétablir seule. (Sécurité publique Canada)</li>
   </ul>
 DATA_COMP: >-
-  Les pertes économiques directement attribuables à des catastrophes sont calculées comme un pourcentage du produit intérieur brut (PIB) en prix courants :
+  Pour chaque année, les pertes économiques directement attribuables à des catastrophes sont calculées comme un pourcentage du produit intérieur brut (PIB) en prix courants :
   <br>
-  Pertes économiques directement attribuables à des catastrophes / PIB en prix courants × 100
+  Coût total estimé / PIB en prix courants × 100
 REC_USE_LIM: >-
   Cet indicateur est un proxy mesurant les pertes économiques directement attribuables à des catastrophes par rapport au produit intérieur brut (PIB) du Canada, tandis que l'indicateur global de l'ONU indique : « Pertes économiques directement attribuables à des catastrophes par rapport au produit intérieur brut mondial (PIB) »
   <br><br>

--- a/meta/fr/11-5-2.yml
+++ b/meta/fr/11-5-2.yml
@@ -1,13 +1,12 @@
 # National
-SDG_GOAL: '<p>Objectif 11 : Faire en sorte que les villes et les établissements humains
-  soient ouverts à tous, sûrs, résilients et durables</p>'
+SDG_GOAL: '<p>Objectif 11 : Faire en sorte que les villes et les établissements humains soient ouverts à tous, sûrs, résilients et durables</p>'
 SDG_TARGET: >-
   Cible 11.5 : D’ici à 2030, renforcer la résilience des pauvres et des personnes en situation vulnérable et réduire leur exposition aux phénomènes climatiques extrêmes et à d’autres chocs et catastrophes d’ordre économique, social ou environnemental et leur vulnérabilité
 SDG_INDICATOR: >-
   Indicateur 11.5.2 : Pertes économiques directement attribuables à des catastrophes par rapport au produit intérieur brut (PIB)
 STAT_CONC_DEF: >-
   <p><strong>Définition :</strong><br>
-  Cet indicateur mesure les pertes économiques directement attribuables à des catastrophes par rapport au produit intérieur brut mondial (PIB).
+  Cet indicateur mesure les pertes économiques directement attribuables à des catastrophes par rapport au produit intérieur brut mondial (PIB).</p>
   <p><strong>Concepts :</strong><br>
   Perte économique : impact économique total composé d’une perte économique directe et d’une perte économique indirecte.
   <br><br>
@@ -17,7 +16,7 @@ STAT_CONC_DEF: >-
   <p>La Base de données canadienne sur les catastrophes (BDC) permet de trouver les « catastrophes importantes » qui correspondent à la définition utilisée dans le document Un cadre de sécurité civile pour le Canada et satisfont à l'un ou à plusieurs des critères suivants :</p>
   <ul>
   <li>dix personnes ou plus ont été tuées ;</li>
-  <li>cent personnes ou plus ont été touchées, blessées, infectées, évacuées ou se sont trouvées sans logement;</li>
+  <li>cent personnes ou plus ont été touchées, blessées, infectées, évacuées ou se sont trouvées sans logement ;</li>
   <li>une demande d'aide a été effectuée à l'échelle nationale ou internationale ;</li>
   <li>la catastrophe revêt une importance historique ;</li>
   <li>les dommages ou l'interruption des processus normaux étaient tels que la collectivité touchée n'a pu se rétablir seule. (Sécurité publique Canada)</li>
@@ -36,8 +35,7 @@ REC_USE_LIM: >-
 proxy: proxy
 
 # Global
-SDG_GOAL__GLOBAL: '<p>Objectif 11 : Faire en sorte que les villes et les établissements
-  humains soient ouverts à tous, sûrs, résilients et durables</p>'
+SDG_GOAL__GLOBAL: '<p>Objectif 11 : Faire en sorte que les villes et les établissements humains soient ouverts à tous, sûrs, résilients et durables</p>'
 SDG_TARGET__GLOBAL: >-
   Cible 11.5 : D’ici à 2030, renforcer la résilience des pauvres et des personnes en situation vulnérable et réduire leur exposition aux phénomènes climatiques extrêmes et à d’autres chocs et catastrophes d’ordre économique, social ou environnemental et leur vulnérabilité
 SDG_INDICATOR__GLOBAL: >-

--- a/meta/fr/11-5-2.yml
+++ b/meta/fr/11-5-2.yml
@@ -6,9 +6,10 @@ SDG_TARGET: >-
 SDG_INDICATOR: >-
   Indicateur 11.5.2 : Pertes économiques directement attribuables à des catastrophes par rapport au produit intérieur brut (PIB)
 STAT_CONC_DEF: >-
-  <p>strong>Définition :</strong><br>
+  <p><strong>Définition :</strong><br>
   Cet indicateur mesure les pertes économiques directement attribuables à des catastrophes par rapport au produit intérieur brut mondial (PIB).
-  <p><strong>Concepts :</strong><br>Perte économique : impact économique total composé d’une perte économique directe et d’une perte économique indirecte.
+  <p><strong>Concepts :</strong><br>
+  Perte économique : impact économique total composé d’une perte économique directe et d’une perte économique indirecte.
   <br><br>
   Perte économique directe : la valeur monétaire de la destruction totale ou partielle des actifs physiques existant dans la zone touchée. Les pertes économiques directes sont presque équivalentes aux dommages physiques.
   <br><br>
@@ -30,7 +31,7 @@ REC_USE_LIM: >-
   <br><br>
   Il est important de noter que la BDC pourrait ne pas convenir aux analyses comparatives en raison des écarts de responsabilités entre les différentes administrations, du type de données disponibles et des façons de les recueillir et les utiliser au fil du temps. 
   <br><br>
-  Les renseignements présentés dans la BDC sont fondés sur des données fournies par des tiers et pourraient ne pas être exacts. (Sécurité publique Canada)'
+  Les renseignements présentés dans la BDC sont fondés sur des données fournies par des tiers et pourraient ne pas être exacts. (Sécurité publique Canada)
 
 proxy: proxy
 

--- a/meta/fr/13-1-1.yml
+++ b/meta/fr/13-1-1.yml
@@ -1,12 +1,34 @@
-SDG_GOAL: '<p>Objectif 13 : Prendre d’urgence des mesures pour lutter contre les changements 
-  climatiques et leurs répercussions</p>'
-SDG_TARGET: '<p>Cible 13.1 : Renforcer, dans tous les pays, la résilience et les capacités 
-  d’adaptation face aux aléas climatiques et aux catastrophes naturelles liées au climat</p>'
-SDG_INDICATOR: '<p>Indicateur 13.1.1 : Nombre de personnes décédées, disparues ou directement 
-  touchées lors de catastrophes, par 100 000 personnes</p>'
-STAT_CONC_DEF: '   '
-DATA_COMP: '   '
-REC_USE_LIM: '   '
+# National
+SDG_GOAL: '<p>Objectif 13 : Prendre d’urgence des mesures pour lutter contre les changements climatiques et leurs répercussions</p>'
+SDG_TARGET: >-
+  Cible 13.1 : Renforcer, dans tous les pays, la résilience et les capacités d’adaptation face aux aléas climatiques et aux catastrophes naturelles liées au climat
+SDG_INDICATOR: >-
+  Indicateur 13.1.1 : Nombre de personnes décédées, disparues ou directement touchées lors de catastrophes, par 100 000 personnes
+STAT_CONC_DEF: >-
+  <p><strong>Définition :</strong><br>
+  Cet indicateur mesure le nombre de personnes décédées, disparues ou directement touchées lors de catastrophes, par 100 000 personnes.</p>
+  <p><strong>Concepts :</strong><br>
+  Décédées : nombre de personnes décédées pendant la catastrophe, ou immédiatement après, en conséquence directe de l'événement dangereux. 
+  <br><br>
+  Disparues : nombre de personnes dont on ne sait pas où elles se trouvent depuis l'événement dangereux. Cela inclut les personnes présumées mortes, pour lesquelles il n’existe aucune preuve physique telle qu’un corps, et pour lesquelles un rapport officiel/légal a été déposé auprès des autorités compétentes.
+  <br><br>
+  Directement touchées : le nombre de personnes ayant subi une blessure, une maladie ou d'autres problèmes de santé ; qui ont été évacuées, déplacées, relocalisées ou qui ont subi des dommages directs à leurs moyens de subsistance et à leurs biens économiques, physiques, sociaux, culturels et environnementaux. Sont indirectement touchées les personnes qui ont subi des conséquences, autres ou en plus des effets directs, au fil du temps, en raison de perturbations ou de changements dans l'économie, les infrastructures critiques, les services de base, le commerce ou le travail, ou de conséquences sociales, sanitaires et psychologiques.</p>
+  <p>La Base de données canadienne sur les catastrophes (BDC) permet de trouver les « catastrophes importantes » qui correspondent à la définition utilisée dans le document Un cadre de sécurité civile pour le Canada et satisfont à l'un ou à plusieurs des critères suivants :</p>
+  <ul>
+  <li>dix personnes ou plus ont été tuées ;</li>
+  <li>cent personnes ou plus ont été touchées, blessées, infectées, évacuées ou se sont trouvées sans logement ;</li>
+  <li>une demande d'aide a été effectuée à l'échelle nationale ou internationale ;</li>
+  <li>la catastrophe revêt une importance historique ;</li>
+  <li>les dommages ou l'interruption des processus normaux étaient tels que la collectivité touchée n'a pu se rétablir seule. (Sécurité publique Canada)</li>
+  </ul>
+DATA_COMP: >-
+  Nombre de personnes décédées, disparues ou directement touchées lors de catastrophes) / Population) x 100,000 = Taux par 100,000 habitants
+REC_USE_LIM: >-
+  Il est important de noter que la BDC pourrait ne pas convenir aux analyses comparatives en raison des écarts de responsabilités entre les différentes administrations, du type de données disponibles et des façons de les recueillir et les utiliser au fil du temps. 
+  <br><br>
+  Les renseignements présentés dans la Banque de données canadienne sur les catastrophes sont fondés sur des données fournies par des tiers et pourraient ne pas être exacts. (Sécurité publique Canada)
+
+# Global
 SDG_GOAL__GLOBAL: '<p>Objectif 13 : Prendre d’urgence des mesures pour lutter contre les changements 
   climatiques et leurs répercussions</p>'
 SDG_TARGET__GLOBAL: '<p>Cible 13.1 : Renforcer, dans tous les pays, la résilience et les capacités 
@@ -14,24 +36,24 @@ SDG_TARGET__GLOBAL: '<p>Cible 13.1 : Renforcer, dans tous les pays, la résilie
 SDG_INDICATOR__GLOBAL: '<p>Indicateur 13.1.1 : Nombre de personnes décédées, disparues ou directement 
   touchées lors de catastrophes, par 100 000 personnes</p>'
 
-reporting_status: complete
+un_designated_tier: Niveau I
+un_custodian_agency: Bureau des Nations Unies pour la réduction des risques des catastrophes (UNDRR)
+goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-13-01-01.pdf
+goal_meta_link_text: Métadonnées des objectifs de développement durable des Nations Unies 
 
+# Source(s)
 source_active_1: 'true'
-source_url_text_1: |
-    Sécurité publique Canada. Base de données canadienne sur les catastrophes
+source_url_text_1: Sécurité publique Canada. Base de données canadienne sur les catastrophes
 source_url_1: https://www.securitepublique.gc.ca/cnt/rsrcs/cndn-dsstr-dtbs/index-fr.aspx
 source_organisation_1: Sécurité publique Canada
+source_periodicity_1: Occasionnelle
+source_geographical_coverage_1: Canada, Région géographique du Canada, Province ou territoire
 
 source_active_2: 'true'
 source_url_text_2: 'Tableau 17-10-0005-01  Estimations de la population au 1er juillet, par âge et sexe'
 source_url_2: https://doi.org/10.25318/1710000501-fra
-source_organisation_2: Statistics Canada
-source_periodicity_2: Annual
-source_geographical_coverage_2: Canada, Province or territory
-
-un_designated_tier: Niveau I
-un_custodian_agency: Bureau des Nations Unies pour la Réduction des Risques de Catastrophes (UNDRR)
-goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-13-01-01.pdf
-goal_meta_link_text: Métadonnées des objectifs de développement durable des Nations Unies 
+source_organisation_2: Statistique Canada
+source_periodicity_2: Annuelle
+source_geographical_coverage_2: Canada, Province ou territoire
 
  

--- a/translations/en/data.yml
+++ b/translations/en/data.yml
@@ -262,17 +262,26 @@ Percentage of mothers with a child aged 12 months or less that received maternit
 
 ## 1-5-1
 Type of natural disaster: Type of natural disaster
-Meteorological - Flood: Meteorological - Flood
-Meteorological - Storm: Meteorological - Storm
-Meteorological - Tornado: Meteorological - Tornado
-Meteorological - Wildfire: Meteorological - Wildfire
-Meteorological - Winter storm: Meteorological - Winter storm
-Meteorological - Heat event: Meteorological - Heat event
-Meteorological - Hurricane: Meteorological - Hurricane
-Mortality rate per 100,000 population: Mortality rate per 100,000 population
-
-## 1-5-2
-Economic loss CAN dollars $/GDP: Economic loss CAN dollars $/GDP
+Epidemic: Epidemic
+Infestation: Infestation
+Pandemic: Pandemic
+Avalanche: Avalanche
+Cold Event: Cold Event
+Drought: Drought
+Flood: Flood
+Geomagnetic Storm: Geomagnetic Storm
+Heat Event: Heat Event
+Hurricane / Typhoon / Tropical Storm: Hurricane / Typhoon / Tropical Storm
+Storm - Unspecified / Other: Storm - Unspecified / Other
+Storm Surge: Storm Surge
+Storms and Severe Thunderstorms: Storms and Severe Thunderstorms
+Tornado: Tornado
+Wildfire: Wildfire
+Winter Storm: Winter Storm
+Earthquake: Earthquake
+Landslide: Landslide
+Tsunami: Tsunami
+Volcano: Volcano
 
 ## 2-1-1
 Household food security status: Household food security status
@@ -1311,22 +1320,6 @@ Level of government: Level of government
 Consolidated Canadian general government: Consolidated Canadian general government
 Consolidated provincial-territorial and local governments: Consolidated provincial-territorial and local governments
 
-## 11-5-1
-Type of commute: Type of commute
-Public transit: Public transit
-Active transport: Active transport
-Trois-Rivieres, Quebec: Trois-Rivieres, Quebec
-Mortality rate per 100,000 population: Mortality rate per 100,000 population
-Number of deaths: Number of deaths
-Type of natural disaster: Type of natural disaster
-Meteorological - Flood: Meteorological - Flood
-Meteorological - Storm: Meteorological - Storm
-Meteorological - Tornado: Meteorological - Tornado
-Meteorological - Wildfire: Meteorological - Wildfire
-Meteorological - Winter storm: Meteorological - Winter storm
-Meteorological - Heat event: Meteorological - Heat event
-Meteorological - Hurricane: Meteorological - Hurricane
-
 ## 11-6-1
 Sources of waste for disposal: Sources of waste for disposal
 All sources of waste for disposal: All sources of waste for disposal
@@ -1428,17 +1421,6 @@ Non-residential sources of diverted materials: Non-residential sources of divert
 Table: Table
 Tourism Satellite Account (TSA): Tourism Satellite Account (TSA)
 System of Environmental Economic Accounting (SEEA): System of Environmental Economic Accounting (SEEA)
-
-## 13-1-1
-Type of natural disaster: Type of natural disaster
-Meteorological - Flood: Meteorological - Flood
-Meteorological - Heat Event: Meteorological - Heat Event
-Meteorological - Hurricane: Meteorological - Hurricane
-Meteorological - Storm: Meteorological - Storm
-Meteorological - Tornado: Meteorological - Tornado
-Meteorological - Wildfire: Meteorological - Wildfire
-Meteorological - Winter Storm: Meteorological - Winter Storm
-Meteorological - Epidemic: Meteorological - Epidemic
 
 ## 13-2-2
 Source: Source

--- a/translations/fr/data.yml
+++ b/translations/fr/data.yml
@@ -299,17 +299,26 @@ Province or territory: Province ou territoire
 
 ## 1-5-1
 Type of natural disaster: Type de catastrophe naturelle
-Meteorological - Flood: Météorologique - Inondation
-Meteorological - Storm: Météorologique - Tempête
-Meteorological - Tornado: Météorologique - Tornade
-Meteorological - Wildfire: Météorologique - Feu de forêt
-Meteorological - Winter storm: Météorologique - Tempête hivernale
-Meteorological - Heat event: Météorologique - Épisode de chaleur
-Meteorological - Hurricane: Météorologique - Ouragan
-Meteorological - Epidemic: Météorologique - Épidémie
-
-## 1-5-2
-Economic loss CAN dollars $/GDP: Perte économique dollars canadiens/PIB
+Epidemic: Épidémie
+Infestation: Infestation
+Pandemic: Pandémie
+Avalanche: Avalanche
+Cold Event: Épisode froid
+Drought: Sécheresse
+Flood: Inondation
+Geomagnetic Storm: Orage géomagnétique
+Heat Event: Épisode de chaleur
+Hurricane / Typhoon / Tropical Storm: Ouragan / typhon / tempête tropicale
+Storm - Unspecified / Other: Tempête-non précisée / autre
+Storm Surge: Onde de tempête
+Storms and Severe Thunderstorms: Orages et orages graves
+Tornado: Tornade
+Wildfire: Feu de forêt
+Winter Storm: Tempête hivernale
+Earthquake: Tremblement de terre
+Landslide: Éboulement
+Tsunami: Tsunami
+Volcano: Volcan
 
 ## 1-a-1
 Basic education: Éducation de base
@@ -1595,22 +1604,6 @@ Consolidated Canadian general government: Administration publique générale can
 Consolidated provincial-territorial and local governments: Administrations publiques provinciales-territoriales et locales consolidées
 Level of government: Niveau de gouvernement
 
-## 11-5-1
-Type of commute: Type de navettage
-Public transit: Transport en commun
-Active transport: Transport actif
-Trois-Rivieres, Quebec: Trois-Rivières, Québec
-Mortality rate per 100,000 population: Taux de mortalité par 100 000 habitants
-Number of deaths: Nombre de décès
-Type of natural disaster: Type de catastrophe naturelle
-Meteorological - Flood: Météorologique - Inondation
-Meteorological - Storm: Météorologique - Tempête
-Meteorological - Tornado: Météorologique - Tornade
-Meteorological - Wildfire: Météorologique - Feu de forêt
-Meteorological - Winter storm: Météorologique - Tempête hivernale
-Meteorological - Heat event: Météorologique - Épisode de chaleur
-Meteorological - Hurricane: Météorologique - Ouragan
-
 ## 11-6-1
 Sources of waste for disposal: Sources des déchets à des fins d'élimination
 All sources of waste for disposal: Toutes les sources de déchets à des fins d'élimination
@@ -1768,16 +1761,6 @@ Non-residential sources of diverted materials: Sources des matières non réside
 Table: Tableau
 Tourism Satellite Account (TSA): Compte satellite du tourisme (CST)
 System of Environmental Economic Accounting (SEEA): Système de comptabilité économique et environnementale (SCEE)
-
-## 13-1-1
-Type of natural disaster: Type de catastrophe naturelle
-Meteorological - Flood: Météorologique - Inondation
-Meteorological - Heat Event: Météorologique - Épisode de chaleur
-Meteorological - Hurricane: Météorologique - Ouragan
-Meteorological - Storm: Météorologique - Tempête
-Meteorological - Tornado: Météorologique - Tornade
-Meteorological - Wildfire: Météorologique - Feu de forêt
-Meteorological - Winter Storm: Météorologique - Tempête hivernale
 
 ## 13-2-2
 Source: Source


### PR DESCRIPTION
- #280 
  - Add banner with new proxy name for 1.5.2/11.5.2: Direct economic loss attributed to disasters in relation to gross domestic product (GDP)
  - Metadata improvements and alignment between 1.5.1/11.5.1/13.1.1 as well as 1.5.2/11.5.2
  - Update with most recent data from the Canadian Disaster Database. If all values for a group are missing, the calculation returns NA instead of zero.
  - Add data translations for disaster event types from Canadian Disaster Database