### PR TITLE
Proxy tags

### DIFF
--- a/indicator-config/1-3-1.yml
+++ b/indicator-config/1-3-1.yml
@@ -58,5 +58,9 @@ progress_calculation_options:
 reporting_status: complete
 sort: ''
 standalone: false
-tags: []
+tags: 
+- Proxy
 "\xEF\xBB\xBFcomposite_breakdown_label": ''
+proxy: both
+proxy_series:
+  - Proportion of persons with disabilities receiving benefits

--- a/indicator-config/1-4-1.yml
+++ b/indicator-config/1-4-1.yml
@@ -74,5 +74,9 @@ progress_calculation_options:
 reporting_status: complete
 sort: ''
 standalone: false
-tags: []
+tags: 
+- Proxy
 "\xEF\xBB\xBFcomposite_breakdown_label": ''
+proxy: both
+proxy_series:
+  - Access to basic waste collection services

--- a/indicator-config/1-5-2.yml
+++ b/indicator-config/1-5-2.yml
@@ -33,3 +33,4 @@ sort: ''
 standalone: false
 tags:
   - Proxy
+proxy: proxy

--- a/indicator-config/1-5-3.yml
+++ b/indicator-config/1-5-3.yml
@@ -36,3 +36,4 @@ sort: ''
 standalone: false
 tags:
   - Proxy
+proxy: proxy

--- a/indicator-config/1-5-4.yml
+++ b/indicator-config/1-5-4.yml
@@ -38,3 +38,4 @@ sort: ''
 standalone: false
 tags:
   - Proxy
+proxy: proxy

--- a/indicator-config/11-5-2.yml
+++ b/indicator-config/11-5-2.yml
@@ -33,3 +33,4 @@ sort: ''
 standalone: false
 tags:
   - Proxy
+proxy: proxy

--- a/indicator-config/11-b-1.yml
+++ b/indicator-config/11-b-1.yml
@@ -35,6 +35,7 @@ sort: ''
 standalone: false
 tags:
   - Proxy
+proxy: proxy
 
 # progress calculation options
 auto_progress_calculation: true

--- a/indicator-config/11-b-2.yml
+++ b/indicator-config/11-b-2.yml
@@ -38,3 +38,4 @@ sort: ''
 standalone: false
 tags:
   - Proxy
+proxy: proxy

--- a/indicator-config/12-2-1.yml
+++ b/indicator-config/12-2-1.yml
@@ -38,7 +38,8 @@ progress_calculation_options:
 reporting_status: complete
 sort: ''
 standalone: false
-tags: []
+tags: 
+- Proxy
 "\xEF\xBB\xBFcomposite_breakdown_label": ''
 proxy: both
 proxy_series:

--- a/indicator-config/12-2-2.yml
+++ b/indicator-config/12-2-2.yml
@@ -38,7 +38,8 @@ progress_calculation_options:
 reporting_status: complete
 sort: ''
 standalone: false
-tags: []
+tags:
+- Proxy
 "\xEF\xBB\xBFcomposite_breakdown_label": ''
 proxy: both
 proxy_series:

--- a/indicator-config/13-1-2.yml
+++ b/indicator-config/13-1-2.yml
@@ -36,6 +36,7 @@ sort: ''
 standalone: false
 tags:
   - Proxy
+proxy: proxy
 
 # progress calculation options
 auto_progress_calculation: true

--- a/indicator-config/13-1-3.yml
+++ b/indicator-config/13-1-3.yml
@@ -38,3 +38,4 @@ sort: ''
 standalone: false
 tags:
   - Proxy
+proxy: proxy

--- a/indicator-config/2-4-1.yml
+++ b/indicator-config/2-4-1.yml
@@ -37,7 +37,8 @@ progress_status: moderate_progress
 reporting_status: complete
 sort: ''
 standalone: false
-tags: []
+tags: 
+- Proxy
 "\xEF\xBB\xBFauto_progress_calculation": false
 proxy: both
 proxy_series:

--- a/indicator-config/7-3-1.yml
+++ b/indicator-config/7-3-1.yml
@@ -34,5 +34,6 @@ proxy: proxy
 reporting_status: complete
 sort: ''
 standalone: false
-tags: []
+tags: 
+- Proxy
 "\xEF\xBB\xBFcomposite_breakdown_label": ''

--- a/indicator-config/8-1-1.yml
+++ b/indicator-config/8-1-1.yml
@@ -34,5 +34,6 @@ progress_status: substantial_progress
 reporting_status: complete
 sort: ''
 standalone: false
-tags: []
+tags: 
+- Proxy
 proxy: proxy

--- a/indicator-config/8-10-2.yml
+++ b/indicator-config/8-10-2.yml
@@ -34,5 +34,6 @@ proxy: proxy
 reporting_status: complete
 sort: ''
 standalone: false
-tags: []
+tags:
+- Proxy
 "\xEF\xBB\xBFcomposite_breakdown_label": ''

--- a/indicator-config/8-2-1.yml
+++ b/indicator-config/8-2-1.yml
@@ -35,4 +35,5 @@ proxy: proxy
 reporting_status: complete
 sort: ''
 standalone: false
-tags: []
+tags: 
+- Proxy

--- a/indicator-config/8-4-1.yml
+++ b/indicator-config/8-4-1.yml
@@ -38,7 +38,8 @@ progress_calculation_options:
 reporting_status: complete
 sort: ''
 standalone: false
-tags: []
+tags: 
+- Proxy
 "\xEF\xBB\xBFcomposite_breakdown_label": ''
 proxy: both
 proxy_series:

--- a/indicator-config/8-4-2.yml
+++ b/indicator-config/8-4-2.yml
@@ -38,7 +38,8 @@ progress_calculation_options:
 reporting_status: complete
 sort: ''
 standalone: false
-tags: []
+tags: 
+- Proxy
 "\xEF\xBB\xBFcomposite_breakdown_label": ''
 proxy: both
 proxy_series:

--- a/indicator-config/fr/1-5-3.yml
+++ b/indicator-config/fr/1-5-3.yml
@@ -35,3 +35,4 @@ sort: ''
 standalone: false
 tags:
   - Proxy
+proxy: proxy

--- a/indicator-config/fr/1-5-4.yml
+++ b/indicator-config/fr/1-5-4.yml
@@ -40,3 +40,4 @@ reporting_status: complete
 sort: ''
 tags:
   - Proxy
+proxy: proxy

--- a/indicator-config/fr/11-b-1.yml
+++ b/indicator-config/fr/11-b-1.yml
@@ -35,3 +35,4 @@ sort: ''
 standalone: false
 tags:
   - Proxy
+proxy: proxy

--- a/indicator-config/fr/11-b-2.yml
+++ b/indicator-config/fr/11-b-2.yml
@@ -40,3 +40,4 @@ sort: ''
 standalone: false
 tags:
   - Proxy
+proxy: proxy

--- a/indicator-config/fr/13-1-2.yml
+++ b/indicator-config/fr/13-1-2.yml
@@ -35,3 +35,4 @@ sort: ''
 standalone: false
 tags:
   - Proxy
+proxy: proxy

--- a/indicator-config/fr/13-1-3.yml
+++ b/indicator-config/fr/13-1-3.yml
@@ -38,4 +38,6 @@ progress_calculation_options:
 reporting_status: complete
 sort: ''
 standalone: false
-tags: []
+tags: 
+- Proxy
+proxy: proxy

--- a/indicator-config/fr/2-4-1.yml
+++ b/indicator-config/fr/2-4-1.yml
@@ -37,7 +37,8 @@ progress_status: moderate_progress
 reporting_status: complete
 sort: ''
 standalone: false
-tags: []
+tags: 
+- Proxy
 "\xEF\xBB\xBFauto_progress_calculation": false
 proxy: both
 proxy_series:

--- a/meta/1-3-1.yml
+++ b/meta/1-3-1.yml
@@ -56,7 +56,3 @@ source_organisation_3: |
   Statistics Canada
 source_periodicity_3: Annual
 source_geographical_coverage_3: Canada
-
-proxy: both
-proxy_series:
-  - Proportion of persons with disabilities receiving benefits

--- a/meta/1-4-1.yml
+++ b/meta/1-4-1.yml
@@ -40,12 +40,6 @@ un_custodian_agency: UN-Habitat
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-01-04-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata
 
-reporting_status: complete
-
-proxy: both
-proxy_series:
-  - Access to basic waste collection services
-
 # SOURCE(S)
 source_active_1: 'true'
 source_url_text_1: "JMP global database"

--- a/meta/1-5-2.yml
+++ b/meta/1-5-2.yml
@@ -32,8 +32,6 @@ REC_USE_LIM: >-
   <br><br>
   The information contained in the Canadian Disaster Database is based on information that is sourced from outside parties and may not be accurate and should therefore be interpreted with caution. (Public Safety Canada)
 
-proxy: proxy
-
 # Global
 SDG_GOAL__GLOBAL: '<p>Goal 1: End poverty in all its forms everywhere</p>'
 SDG_TARGET__GLOBAL: '<p>Target 1.5: By 2030, build the resilience of the poor and those in vulnerable situations and reduce their exposure and vulnerability to climate-related extreme events and other economic, social and environmental shocks and disasters</p>'

--- a/meta/1-5-3.yml
+++ b/meta/1-5-3.yml
@@ -28,5 +28,3 @@ source_url_text_1: |
 source_url_1: https://www.publicsafety.gc.ca/cnt/rsrcs/pblctns/mrgncy-mngmnt-strtgy/index-en.aspx
 source_organisation_1: Public Safety Canada
 source_geographical_coverage_1: Canada
-
-proxy: proxy

--- a/meta/1-5-4.yml
+++ b/meta/1-5-4.yml
@@ -32,7 +32,3 @@ source_url_text_2: |
 source_url_2: https://www.quebec.ca/gouvernement/ministere/securite-publique/publications/politique-quebecoise-securite-civile-2014-2024
 source_organisation_2: Gouvernement of Quebec
 source_geographical_coverage_2: Quebec
-
-reporting_status: complete
-
-proxy: proxy

--- a/meta/11-5-2.yml
+++ b/meta/11-5-2.yml
@@ -32,8 +32,6 @@ REC_USE_LIM: >-
   <br><br>
   The information contained in the Canadian Disaster Database is based on information that is sourced from outside parties and may not be accurate and should therefore be interpreted with caution. (Public Safety Canada)
 
-proxy: proxy
-
 # Global
 SDG_GOAL__GLOBAL: '<p>Goal 11: Make cities and human settlements inclusive, safe, resilient and sustainable</p>'
 SDG_TARGET__GLOBAL: >-

--- a/meta/11-b-1.yml
+++ b/meta/11-b-1.yml
@@ -32,7 +32,3 @@ source_url_text_1: |
 source_url_1: https://www.publicsafety.gc.ca/cnt/rsrcs/pblctns/mrgncy-mngmnt-strtgy/index-en.aspx
 source_organisation_1: Public Safety Canada
 source_geographical_coverage_1: Canada
-
-reporting_status: complete
-
-proxy: proxy

--- a/meta/11-b-2.yml
+++ b/meta/11-b-2.yml
@@ -37,7 +37,3 @@ source_url_text_2: |
 source_url_2: https://www.quebec.ca/gouvernement/ministere/securite-publique/publications/politique-quebecoise-securite-civile-2014-2024
 source_organisation_2: Gouvernement of Quebec
 source_geographical_coverage_2: Quebec
-
-reporting_status: complete
-
-proxy: proxy

--- a/meta/13-1-2.yml
+++ b/meta/13-1-2.yml
@@ -13,6 +13,7 @@ SDG_TARGET__GLOBAL: '<p>Target 13.1: Strengthen resilience and adaptive capacity
 SDG_INDICATOR__GLOBAL: '<p>Indicator 13.1.2: Number of countries that adopt and implement national disaster 
   risk reduction strategies in line with the Sendai Framework for Disaster Risk Reduction 
   2015–2030</p>'
+  
 un_designated_tier: Tier II
 un_custodian_agency: United Nations International Strategy for Disaster Reduction (UNISDR)
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-13-01-02.pdf
@@ -24,7 +25,3 @@ source_url_text_1: |
 source_url_1: https://www.publicsafety.gc.ca/cnt/rsrcs/pblctns/mrgncy-mngmnt-strtgy/index-en.aspx
 source_organisation_1: Public Safety Canada
 source_geographical_coverage_1: Canada
-
-reporting_status: complete
-
-proxy: proxy

--- a/meta/13-1-3.yml
+++ b/meta/13-1-3.yml
@@ -28,7 +28,3 @@ source_url_text_2: |
 source_url_2: https://www.quebec.ca/gouvernement/ministere/securite-publique/publications/politique-quebecoise-securite-civile-2014-2024
 source_organisation_2: Gouvernement of Quebec
 source_geographical_coverage_2: Quebec
-
-reporting_status: complete
-
-proxy: proxy

--- a/meta/fr/1-3-1.yml
+++ b/meta/fr/1-3-1.yml
@@ -56,7 +56,3 @@ un_designated_tier: Niveau II
 un_custodian_agency: Organisation internationale du Travail, Banque Mondiale
 goal_meta_link: https://unstats.un.org/sdgs/metadata/?Text=&Goal=1&Target=1.3
 goal_meta_link_text: Métadonnées des objectifs de développement durable des Nations Unies
-
-proxy: both
-proxy_series:
-  - Proportion of persons with disabilities receiving benefits

--- a/meta/fr/1-4-1.yml
+++ b/meta/fr/1-4-1.yml
@@ -40,12 +40,6 @@ SDG_TARGET__GLOBAL: '<p>Cible 1.4 : D''ici à 2030, faire en sorte que tous les 
 SDG_INDICATOR__GLOBAL: '<p>Indicateur 1.4.1 : Proportion de la population vivant dans
   des ménages ayant accès aux services de base </p>'
 
-reporting_status: complete
-
-proxy: both
-proxy_series:
-  - Access to basic waste collection services
-
 un_designated_tier: Niveau I
 un_custodian_agency: ONU-Habitat
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-01-04-01.pdf

--- a/meta/fr/1-5-2.yml
+++ b/meta/fr/1-5-2.yml
@@ -31,8 +31,6 @@ REC_USE_LIM: >-
   <br><br>
   Les renseignements présentés dans la BDC sont fondés sur des données fournies par des tiers et pourraient ne pas être exacts. (Sécurité publique Canada)
 
-proxy: proxy
-
 # Global
 SDG_GOAL__GLOBAL: '<p>Objectif 1 : Éliminer la pauvreté sous toutes ses formes et partout dans le monde</p>'
 SDG_TARGET__GLOBAL: "<p>Cible 1.5 : D’ici à 2030, renforcer la résilience des pauvres et des personnes en situation vulnérable et réduire leur exposition aux phénomènes climatiques extrêmes et à d’autres chocs et catastrophes d’ordre économique, social ou environnemental et leur vulnérabilité</p>"

--- a/meta/fr/1-5-3.yml
+++ b/meta/fr/1-5-3.yml
@@ -21,5 +21,3 @@ source_url_text_1: |
 source_url_1: https://www.securitepublique.gc.ca/cnt/rsrcs/pblctns/mrgncy-mngmnt-strtgy/index-fr.aspx
 source_organisation_1: Sécurité publique Canada
 source_geographical_coverage_1: Canada
-
-proxy: proxy

--- a/meta/fr/1-5-4.yml
+++ b/meta/fr/1-5-4.yml
@@ -26,7 +26,3 @@ source_url_text_2: |
 source_url_2: https://www.quebec.ca/gouvernement/ministere/securite-publique/publications/politique-quebecoise-securite-civile-2014-2024
 source_organisation_2: Gouvernement du Québec
 source_geographical_coverage_2: Québec
-
-reporting_status: complete
-
-proxy: proxy

--- a/meta/fr/11-5-2.yml
+++ b/meta/fr/11-5-2.yml
@@ -32,8 +32,6 @@ REC_USE_LIM: >-
   <br><br>
   Les renseignements présentés dans la BDC sont fondés sur des données fournies par des tiers et pourraient ne pas être exacts. (Sécurité publique Canada)
 
-proxy: proxy
-
 # Global
 SDG_GOAL__GLOBAL: '<p>Objectif 11 : Faire en sorte que les villes et les établissements humains soient ouverts à tous, sûrs, résilients et durables</p>'
 SDG_TARGET__GLOBAL: >-

--- a/meta/fr/11-b-1.yml
+++ b/meta/fr/11-b-1.yml
@@ -36,5 +36,3 @@ source_url_text_1: |
 source_url_1: https://www.securitepublique.gc.ca/cnt/rsrcs/pblctns/mrgncy-mngmnt-strtgy/index-fr.aspx
 source_organisation_1: Sécurité publique Canada
 source_geographical_coverage_1: Canada
-
-proxy: proxy

--- a/meta/fr/11-b-2.yml
+++ b/meta/fr/11-b-2.yml
@@ -29,8 +29,6 @@ un_custodian_agency: Stratégie internationale des Nations Unies pour la préven
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-11-0b-02.pdf
 goal_meta_link_text: Métadonnées des objectifs de développement durable des Nations Unies
 
-reporting_status: complete
-
 source_active_1: 'true'
 source_url_text_1: |
     Gouvernement de la Colombie-Britannique. Modernizing BC’s Emergency Management Legislation (En anglais seulement)
@@ -44,5 +42,3 @@ source_url_text_2: |
 source_url_2: https://www.quebec.ca/gouvernement/ministere/securite-publique/publications/politique-quebecoise-securite-civile-2014-2024
 source_organisation_2: Gouvernement du Québec
 source_geographical_coverage_2: Québec
-
-proxy: proxy

--- a/meta/fr/13-1-2.yml
+++ b/meta/fr/13-1-2.yml
@@ -15,12 +15,11 @@ SDG_TARGET__GLOBAL: '<p>Cible 13.1 : Renforcer, dans tous les pays, la résilie
 SDG_INDICATOR__GLOBAL: '<p>Indicateur 13.1.2 : Nombre de pays ayant adopté et mis en place des stratégies
   nationales de réduction des risques, conformément au Cadre de Sendai pour la réduction des risques 
   de catastrophe (2015-2030)</p>'
+  
 un_designated_tier: Niveau II
 un_custodian_agency: Stratégie internationale de prévention des catastrophes des Nations Unies (UNISDR)
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-13-01-02.pdf
 goal_meta_link_text: Métadonnées des objectifs de développement durable des Nations Unies 
-
-reporting_status: complete
 
 source_active_1: 'true'
 source_url_text_1: |
@@ -28,5 +27,3 @@ source_url_text_1: |
 source_url_1: https://www.securitepublique.gc.ca/cnt/rsrcs/pblctns/mrgncy-mngmnt-strtgy/index-fr.aspx
 source_organisation_1: Sécurité publique Canada
 source_geographical_coverage_1: Canada
-
-proxy: proxy

--- a/meta/fr/13-1-3.yml
+++ b/meta/fr/13-1-3.yml
@@ -14,8 +14,6 @@ SDG_INDICATOR__GLOBAL: '<p>Indicateur 13.1.3 : Proportion d’administrations lo
   mis en place des stratégies locales de réduction des risques de catastrophe, conformément 
   aux stratégies suivies à l’échelle nationale</p>'
 
-reporting_status: complete
-
 source_active_1: 'true'
 source_url_text_1: |
     Gouvernement de la Colombie-Britannique. Modernizing BC’s Emergency Management Legislation (En anglais seulement)
@@ -34,5 +32,3 @@ un_designated_tier: Niveau II
 un_custodian_agency: Stratégie internationale de prévention des catastrophes des Nations Unies (UNISDR)
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-13-01-03.pdf
 goal_meta_link_text: Métadonnées des objectifs de développement durable des Nations Unies 
-
-proxy: proxy


### PR DESCRIPTION
Add missing proxy tags on goals pages and move all proxy configuration settings from the metadata files to the indicator-config files for Goals 1, 2, 4, 6, 7, 8, 12, 14.