### PR TITLE
Show graphs 16.9.1 and 16.10.2

### DIFF
--- a/indicator-config/16-10-2.yml
+++ b/indicator-config/16-10-2.yml
@@ -3,7 +3,7 @@ composite_breakdown_label: Score [0-9]
 computation_units: ''
 copyright: ''
 data_footnote: ''
-data_non_statistical: true
+data_non_statistical: false
 data_notice_class: ''
 data_notice_heading: ''
 data_notice_text: ''

--- a/indicator-config/16-9-1.yml
+++ b/indicator-config/16-9-1.yml
@@ -2,7 +2,7 @@ auto_progress_calculation: true
 computation_units: Percentage (%)
 copyright: ''
 data_footnote: ''
-data_non_statistical: true
+data_non_statistical: false
 data_notice_class: ''
 data_notice_heading: ''
 data_notice_text: ''

--- a/indicator-config/fr/16-10-2.yml
+++ b/indicator-config/fr/16-10-2.yml
@@ -2,7 +2,7 @@
 computation_units: Score [0-9]
 copyright: ''
 data_footnote: ''
-data_non_statistical: true
+data_non_statistical: false
 data_notice_class: ''
 data_notice_heading: ''
 data_notice_text: ''


### PR DESCRIPTION
Change data_non_statistical settings to false for indicators 16.9.1 and 16.10.2 so that the graphs are displayed.
- #295 
- #296 