### PR TITLE
Various fixes for new GIF indicators

### DIFF
--- a/indicator-config/11-c-1.yml
+++ b/indicator-config/11-c-1.yml
@@ -3,9 +3,9 @@ computation_units: ""
 copyright: ""
 data_footnote: ""
 data_non_statistical: false
-data_notice_class: ""
-data_notice_heading: ""
-data_notice_text: ""
+data_notice_class: success
+data_notice_heading: custom.exploring-data-sources-header
+data_notice_text: custom.exploring-data-sources-text
 data_show_map: false
 data_start_values: []
 embedded_feature_footer: ""
@@ -36,7 +36,7 @@ precision: []
 progress_calculation_options:
 - direction: ''
   target: []
-reporting_status: notavailable
+reporting_status: notstarted
 sort: ""
 standalone: false
 tags: []

--- a/indicator-config/2-2-4.yml
+++ b/indicator-config/2-2-4.yml
@@ -3,9 +3,9 @@ computation_units: ""
 copyright: ""
 data_footnote: ""
 data_non_statistical: false
-data_notice_class: ""
-data_notice_heading: ""
-data_notice_text: ""
+data_notice_class: success
+data_notice_heading: custom.exploring-data-sources-header
+data_notice_text: custom.exploring-data-sources-text
 data_show_map: false
 data_start_values: []
 embedded_feature_footer: ""
@@ -41,7 +41,7 @@ precision: []
 progress_calculation_options:
 - direction: positive
   target: []
-reporting_status: notavailable
+reporting_status: notstarted
 sort: ""
 standalone: false
 tags: []

--- a/indicator-config/8-9-2.yml
+++ b/indicator-config/8-9-2.yml
@@ -3,9 +3,9 @@ computation_units: ""
 copyright: ""
 data_footnote: ""
 data_non_statistical: false
-data_notice_class: ""
-data_notice_heading: ""
-data_notice_text: ""
+data_notice_class: success
+data_notice_heading: custom.exploring-data-sources-header
+data_notice_text: custom.exploring-data-sources-text
 data_show_map: false
 data_start_values: []
 embedded_feature_footer: ""
@@ -36,7 +36,7 @@ precision: []
 progress_calculation_options:
 - direction: positive
   target: []
-reporting_status: notavailable
+reporting_status: notstarted
 sort: ""
 standalone: false
 tags: []

--- a/meta/11-c-1.yml
+++ b/meta/11-c-1.yml
@@ -12,8 +12,7 @@ STAT_CONC_DEF: >-
   loans, and technical assistance. Notably Official development assistance focuses solely on development 
   efforts and explicitly excludes military aid.
 DATA_COMP: '     '
-REC_USE_LIM: >-
-  ''
+REC_USE_LIM: ''
 PROGRESS_DETAILS: ''
 
 # Global

--- a/meta/2-2-4.yml
+++ b/meta/2-2-4.yml
@@ -9,6 +9,9 @@ STAT_CONC_DEF: |-
   UNICEF and WHO have defined eight key food groups for infant and young children, which include: 1) breast milk; 2) grains, roots, and tubers; 3) pulses (beans, peas, lentils), nuts and seeds; 4) dairy products (milk, infant formula, yogurt, cheese); 5) flesh foods (meat, fish, poultry, organ meats; 6) eggs; 7) vitamin-A rich fruits and vegetables; and 8)other fruits and vegetables. Minimum dietary diversity is defined as the consumption of at least five out of the eight food groups. Consumption of any amount of food or beverage from a food group is sufficient to “count”, i.e., there is no minimum quantity.
 DATA_COMP: ''
 REC_USE_LIM: ''
+PROGRESS_DETAILS: ''
+
+#Global
 SDG_GOAL__GLOBAL: |-
   Goal 2: End hunger, achieve food security and improved nutrition and promote sustainable agriculture
 SDG_TARGET__GLOBAL: |-
@@ -18,7 +21,7 @@ SDG_INDICATOR__GLOBAL: |-
 
 un_designated_tier: Tier I
 un_custodian_agency: United Nations Children's Fund (UNICEF); Food and Agriculture Organization of the United Nations (FAO)
-goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-02-02-04a.pdf; https://unstats.un.org/sdgs/metadata/files/Metadata-02-02-04b.pdf
+goal_meta_link: https://unstats.un.org/sdgs/metadata?Text=&Goal=2&Target=2.2
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata
 
 # SOURCE(S)

--- a/meta/8-9-2.yml
+++ b/meta/8-9-2.yml
@@ -13,8 +13,8 @@ STAT_CONC_DEF: 'The employed persons comprise “all persons of working age who,
   Organization, 2010).'
 DATA_COMP: '   '
 REC_USE_LIM: '  '
- 
 PROGRESS_DETAILS: ''
+
 
 # GLOBAL
 SDG_GOAL__GLOBAL: '<p>Goal: 8. Promote sustained, inclusive and sustainable economic
@@ -22,6 +22,8 @@ SDG_GOAL__GLOBAL: '<p>Goal: 8. Promote sustained, inclusive and sustainable econ
 SDG_TARGET__GLOBAL: '<p>Target 8.9: By 2030, devise and implement policies to promote
   sustainable tourism that creates jobs and promotes local culture and products </p>'
 SDG_INDICATOR__GLOBAL: '<p>Indicator 8.9.2: Employed persons in the tourism industries </p>'
+
+
 un_designated_tier: ''
 un_custodian_agency: World Tourism Organization (UNTWO)
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-08-09-02.pdf

--- a/meta/fr/11-c-1.yml
+++ b/meta/fr/11-c-1.yml
@@ -11,8 +11,7 @@ STAT_CONC_DEF: >-
   et l'assistance technique. Il convient de noter que l'aide publique au développement se concentre uniquement sur les efforts de développement 
   et exclut explicitement l'aide militaire
 DATA_COMP: '   '
-REC_USE_LIM: >-
-  ''
+REC_USE_LIM: ''
 PROGRESS_DETAILS: ''
 
 # Global

--- a/meta/fr/2-2-4.yml
+++ b/meta/fr/2-2-4.yml
@@ -9,6 +9,7 @@ STAT_CONC_DEF: |-
   L'UNICEF et l'OMS ont défini huit groupes alimentaires clés pour les nourrissons et les jeunes enfants, qui comprennent : 1) le lait maternel ; 2) les céréales, les racines et les tubercules ; 3) les légumineuses (haricots, pois, lentilles), les noix et les graines ; 4) les produits laitiers (lait, préparations pour nourrissons, yaourt, fromage) ; 5) les aliments carnés (viande, poisson, volaille, abats) ; 6) les œufs ; 7) les fruits et légumes riches en vitamine A ; et 8) les autres fruits et légumes. La diversité alimentaire minimale est définie comme la consommation d'au moins cinq des huit groupes alimentaires. La consommation de n'importe quelle quantité d'aliments ou de boissons d'un groupe alimentaire est suffisante pour « compter », c'est-à-dire qu'il n'y a pas de quantité minimale.
 DATA_COMP: ''
 REC_USE_LIM: ''
+PROGRESS_DETAILS: ''
 
 
 # GLOBAL
@@ -18,5 +19,11 @@ SDG_TARGET__GLOBAL: |-
   Cible 2.2 : D’ici 2030, mettre fin à toutes les formes de malnutrition, notamment en atteignant d’ici 2025 les objectifs arrêtés à l’échelle internationale relatifs aux retards de croissance et à l’émaciation chez les enfants de moins de 5 ans, et répondre aux besoins nutritionnels des adolescentes, des femmes enceintes ou allaitantes et des personnes âgées
 SDG_INDICATOR__GLOBAL: |-
   Indicateur 2.2.4 :  Prévalence de la diversité alimentaire minimale, par groupe de population (enfants âgés de 6 à 23,9 mois et femmes non enceintes âgées de 15 à 49 ans
+
+un_designated_tier: Niveau I
+un_custodian_agency: Fonds des Nations Unies pour l'enfance (UNICEF) ; Organisation des Nations Unies pour l'alimentation et l'agriculture (ONUAA)
+goal_meta_link: https://unstats.un.org/sdgs/metadata?Text=&Goal=2&Target=2.2
+goal_meta_link_text: Métadonnées des objectifs de développement durable des Nations Unies
+
 
 # SOURCE(S)

--- a/meta/fr/8-9-2.yml
+++ b/meta/fr/8-9-2.yml
@@ -12,10 +12,8 @@ STAT_CONC_DEF: >-
     comprennent tous les établissements dont l'activité principale est une activité caractéristique du tourisme. Il s'agit d'une 
     activité qui produit généralement des produits caractéristiques du tourisme, tels que définis dans les Recommandations internationales pour les statistiques du tourisme 2008 (IRTS 2008) (Nations Unies et Organisation mondiale du tourisme, 2010).
 
-
-DATA_COMP: '   '
-REC_USE_LIM: '   '
- 
+DATA_COMP: ''
+REC_USE_LIM: ''
 PROGRESS_DETAILS: ''
 
 # GLOBAL


### PR DESCRIPTION
Changes needed to the newly added indicators:

11.c.1

 Change status to Exploring data sources instead of not available
 Extra “ in the comments and limitation field
 Missing a field from the Global Metadata tab (UN designated tier)

2.2.4

 Change status to exploring data sources
 Missing some fields from the national metadata tab
 Broken link for the UN metadata

8.9.2

 Change status to Exploring data sources instead of not available
 Missing some fields from the national metadata tab and global metadata tab