### PR TITLE
Progress details update 3.c.1

### DIFF
--- a/meta/3-c-1.yml
+++ b/meta/3-c-1.yml
@@ -19,7 +19,7 @@ DATA_COMP: |-
   Density of pharmacists = (NOC: 31120 Pharmacists / Population) x 10,000
 REC_USE_LIM: '    '
 PROGRESS_DETAILS: |-
-  The progress status for this indicator is based on the health worker distribution per 10,000 population for all available occupations: medical doctors, nursing and midwifery personnel, dentists, and pharmacists. 
+  The progress status for this indicator is based on the health worker density per 10,000 population for all available occupations: medical doctors, nursing and midwifery personnel, dentists, and pharmacists. 
 
 # Global
 SDG_GOAL__GLOBAL: |-


### PR DESCRIPTION
Updated the description to clarify that the progress status is based on health worker density instead of distribution. The change is only needed in English version - it is correct in the French version. 